### PR TITLE
ACCT-648 Add support for spectrum application

### DIFF
--- a/internal/app/cf-terraforming/cmd/spectrum_application.go
+++ b/internal/app/cf-terraforming/cmd/spectrum_application.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	cloudflare "github.com/cloudflare/cloudflare-go"
+
+	"text/template"
+
+	"github.com/spf13/cobra"
+)
+
+const spectrumApplicationTemplate = `
+resource "cloudflare_spectrum_application" "{{.App.ID}}" {
+    protocol = "{{.App.Protocol}}"
+    dns = {
+        type = "{{.App.DNS.Type}}"
+        name = "{{.App.DNS.Name}}"
+    }
+{{if .App.OriginPort}}
+    origin_port = "{{.App.OriginPort}}"
+{{end}}
+{{if .App.OriginDNS}}
+    origin_dns = {
+      name = "{{.App.OriginDNS.Name}}"
+    }
+{{end}}
+{{if .App.IPFirewall}}
+    ip_firewall = "{{.App.IPFirewall}}"
+{{end}}
+{{if .App.ProxyProtocol}}
+    proxy_protocol = "{{.App.ProxyProtocol}}"
+{{end}}
+{{if .App.TLS}}
+    tls = "{{.App.TLS}}"
+{{end}}
+    origin_direct = [{{range .App.OriginDirect}} "{{.}}", {{end}}]
+}
+`
+
+func init() {
+	rootCmd.AddCommand(spectrumApplicationCmd)
+}
+
+var spectrumApplicationCmd = &cobra.Command{
+	Use:   "spectrum_application",
+	Short: "Import a spectrum application into Terraform",
+	Run: func(cmd *cobra.Command, args []string) {
+		// Loop through all zones in account and fetch routes for each zone
+		for _, zone := range zones {
+			spectrumApplications, err := api.SpectrumApplications(zone.ID)
+
+			if err != nil {
+				// FIXME: api.SpectrumApplications can return 403 errors in the case
+				// of permissions problems, for example, which will pollute tfstate
+				fmt.Println(err)
+				os.Exit(1)
+			}
+
+			if len(spectrumApplications) > 0 {
+				for _, app := range spectrumApplications {
+					spectrumAppParse(app)
+				}
+			}
+		}
+	},
+}
+
+func spectrumAppParse(app cloudflare.SpectrumApplication) {
+	tmpl := template.Must(template.New("script").Funcs(templateFuncMap).Parse(spectrumApplicationTemplate))
+	tmpl.Execute(os.Stdout,
+		struct {
+			App cloudflare.SpectrumApplication
+		}{
+			App: app,
+		})
+}


### PR DESCRIPTION
Implements support for importing ```cloudflare_spectrum_application``` into valid terraform resource format. 

**Usage:**

```
go run cmd/cf-terraforming/main.go --email zackproser@gmail.com --key <redacted> -a 1233d87642b6bc764b5f763af7675d11 spectrum_application
2019/01/25 14:19:37 [DEBUG] API Email = zackproser@gmail.com
2019/01/25 14:19:37 [DEBUG] Initializing cloudflare-go
2019/01/25 14:19:37 [DEBUG] Selecting zones for import
2019/01/25 14:19:37 [INFO] Zones selected:
2019/01/25 14:19:37 [INFO] - ID: 81b061433228f488ab84e5ec83c2dc1e, Name: article-optimize.com
2019/01/25 14:19:37 [INFO] - ID: b119ce10e1c279d0e35693370347ef61, Name: pagegobbler.com
2019/01/25 14:19:37 [INFO] - ID: 4cf98c231516461f2a591d3e6ee6a140, Name: pageripper.net
...
2019/01/25 14:19:37 [INFO] - ID: c467792cd80f055faea18b87e23a45ee, Name: zackproser.com

resource "cloudflare_spectrum_application" "7150bedaf4524eb99f78b9696ca17cbf" {
    protocol = "tcp/8000"
    dns = {
        type = "CNAME"
        name = "article-optimize.com"
    }


    ip_firewall = "true"

    tls = "off"

    origin_direct = [ "tcp://35.231.47.168:8000", ]
}
```