### PR TITLE
SDK-32 Add support for importing cloudflare_load_balancer_pool

### DIFF
--- a/internal/app/cf-terraforming/cmd/load_balancer_pool.go
+++ b/internal/app/cf-terraforming/cmd/load_balancer_pool.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	cloudflare "github.com/cloudflare/cloudflare-go"
+
+	"text/template"
+
+	"github.com/spf13/cobra"
+)
+
+const loadBalancerPoolTemplate = `
+resource "cloudflare_load_balancer_pool" "{{.LBP.ID}}" {
+    name = "{{.LBP.Name}}"
+{{if .LBP.Origins}}
+    {{range .LBP.Origins}}
+    origins {
+        name = "{{.Name}}"
+        address = "{{.Address}}"
+        weight = {{.Weight}}
+        enabled = {{.Enabled}}
+
+    }
+    {{end}}
+{{end}}
+{{if .LBP.Description}}
+    description = "{{.LBP.Description}}"
+{{end}}
+{{if .LBP.Enabled}}
+    enabled = {{.LBP.Enabled}}
+{{end}}
+{{if .LBP.MinimumOrigins}}
+    minimum_origins = {{.LBP.MinimumOrigins}}
+{{end}}
+{{if .LBP.Monitor}}
+    monitor = "{{.LBP.Monitor}}"
+{{end}}
+{{if .LBP.NotificationEmail}}
+    notification_email = "{{.LBP.NotificationEmail}}"
+{{end}}
+}
+`
+
+func init() {
+	rootCmd.AddCommand(loadBalancerPoolCmd)
+}
+
+var loadBalancerPoolCmd = &cobra.Command{
+	Use:   "load_balancer_pool",
+	Short: "Import a load balancer pool into Terraform",
+	Run: func(cmd *cobra.Command, args []string) {
+		loadBalancerPools, err := api.ListLoadBalancerPools()
+
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		if len(loadBalancerPools) > 0 {
+			for _, lbp := range loadBalancerPools {
+				loadBalancerPoolParse(lbp)
+			}
+		}
+
+	},
+}
+
+func loadBalancerPoolParse(lbp cloudflare.LoadBalancerPool) {
+	tmpl := template.Must(template.New("script").Funcs(templateFuncMap).Parse(loadBalancerPoolTemplate))
+	tmpl.Execute(os.Stdout,
+		struct {
+			LBP cloudflare.LoadBalancerPool
+		}{
+			LBP: lbp,
+		})
+}


### PR DESCRIPTION
Implement support for importing ```cloudflare_load_balancer_pool```. 

**Usage:**

```
$ go run cmd/cf-terraforming/main.go --email zackproser@gmail.com --key <redacted> -z pagegobbler.com -a eee138b652ea7cd73cb359a2d9a6c6a8 load_balancer_pool
2019/01/29 12:04:28 [DEBUG] API Email = zackproser@gmail.com
2019/01/29 12:04:28 [DEBUG] Initializing cloudflare-go
2019/01/29 12:04:28 [DEBUG] Selecting zones for import
2019/01/29 12:04:28 [INFO] Zones selected:
2019/01/29 12:04:28 [INFO] - ID: b119ce10e1c279d0e35693370347ef61, Name: pagegobbler.com

resource "cloudflare_load_balancer_pool" "0afe7e71737fcc00d3272afb61f51bb5" {
    name = "us-west1"


    origins {
        name = "server1"
        address = "200.168.2.1"
        weight = 1
        enabled = true

    }

    origins {
        name = "server2"
        address = "200.168.2.2"
        weight = 1
        enabled = true

    }




    enabled = true


    minimum_origins = 1



}
```