### PR TITLE
SDK-35 Implement support for importing access_policy

### DIFF
--- a/internal/app/cf-terraforming/cmd/access_policy.go
+++ b/internal/app/cf-terraforming/cmd/access_policy.go
@@ -1,0 +1,124 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"text/template"
+
+	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/spf13/cobra"
+)
+
+const accessPolicyTemplate = `
+resource "cloudflare_access_policy" "{{.Policy.ID}}" {
+    application_id = "{{.App.ID}}"
+    zone_id = "{{.Zone.ID}}"
+    name = "{{.Policy.Name}}"
+    precedence = "{{.Policy.Precedence}}"
+    decision = "{{.Policy.Decision}}"
+
+{{if .Policy.Include }}
+    include = {
+{{range $k, $v := .Policy.Include }}
+    {{if isMap $v }}
+        {{- range $k, $v := $v }}
+            {{ $k }} =  {{if isMap $v }} [{{range $v}}"{{.}}",{{end}}]  {{else}} "{{ $v }}" {{end}}
+        {{end -}}
+    {{end}}
+{{end}}
+    }
+{{end}}
+
+{{if .Policy.Exclude }}
+    exclude = {
+{{range $k, $v := .Policy.Exclude }}
+    {{if isMap $v }}
+        {{- range $k, $v := $v }}
+            {{ $k }} =  {{if isMap $v }} [{{range $v}}"{{.}}",{{end}}]  {{else}} "{{ $v }}" {{end}}
+        {{end -}}
+    {{end}}
+{{end}}
+    }
+{{end}}
+
+{{if .Policy.Require }}
+    require = {
+{{range $k, $v := .Policy.Require }}
+    {{if isMap $v }}
+        {{- range $k, $v := $v }}
+            {{ $k }} =  {{if isMap $v }} [{{range $v}}"{{.}}",{{end}}]  {{else}} "{{ $v }}" {{end}}
+        {{end -}}
+    {{end}}
+{{end}}
+    }
+{{end}}
+
+}
+`
+
+func init() {
+	rootCmd.AddCommand(accessPolicyCmd)
+}
+
+var accessPolicyCmd = &cobra.Command{
+	Use:   "access_policy",
+	Short: "Import Access Policy data into Terraform",
+	Run: func(cmd *cobra.Command, args []string) {
+		log.Print("Importing Access Policy data")
+
+		for _, zone := range zones {
+			log.Printf("[DEBUG] Processing zone: ID %s, Name %s", zone.ID, zone.Name)
+
+			accessApplications, _, appFetchErr := api.AccessApplications(zone.ID, cloudflare.PaginationOptions{
+				Page:    1,
+				PerPage: 1000,
+			})
+
+			if appFetchErr != nil {
+				fmt.Println(appFetchErr)
+				os.Exit(1)
+			}
+
+			for _, app := range accessApplications {
+
+				accessPolicies, _, err := api.AccessPolicies(zone.ID, app.ID, cloudflare.PaginationOptions{
+					Page:    1,
+					PerPage: 1000,
+				})
+
+				if err != nil {
+					if strings.Contains(err.Error(), "HTTP status 403") {
+						log.Printf("[INFO] insufficient permissions accessing Zone ID %s\n", zone.ID)
+						continue
+					}
+
+					fmt.Println(err)
+					os.Exit(1)
+				}
+
+				for _, policy := range accessPolicies {
+
+					accessPolicyParse(app, policy, zone)
+				}
+			}
+
+		}
+	},
+}
+
+func accessPolicyParse(app cloudflare.AccessApplication, policy cloudflare.AccessPolicy, zone cloudflare.Zone) {
+	tmpl := template.Must(template.New("access_policy").Funcs(templateFuncMap).Parse(accessPolicyTemplate))
+	tmpl.Execute(os.Stdout,
+		struct {
+			App    cloudflare.AccessApplication
+			Policy cloudflare.AccessPolicy
+			Zone   cloudflare.Zone
+		}{
+			App:    app,
+			Policy: policy,
+			Zone:   zone,
+		})
+}


### PR DESCRIPTION
Implements support for importing ```cloudflare_access_policy```

**Usage:**

```
$ go run cmd/cf-terraforming/main.go --email zproser@cloudflare.com --key <redacted> -z cloudflareapitest.com -a d781e89412e1965584dc2a65a43b7fce access_policy
2019/02/01 10:27:20 [DEBUG] API Email = zproser@cloudflare.com
2019/02/01 10:27:20 [DEBUG] Initializing cloudflare-go
2019/02/01 10:27:20 [DEBUG] Selecting zones for import
2019/02/01 10:27:20 [INFO] Zones selected:
2019/02/01 10:27:20 [INFO] - ID: cf535477f63b2257ba5013a592477ca3, Name: cloudflareapitest.com
2019/02/01 10:27:20 Importing Access Policy data
2019/02/01 10:27:20 [DEBUG] Processing zone: ID cf535477f63b2257ba5013a592477ca3, Name cloudflareapitest.com

resource "cloudflare_access_policy" "ad94c8b4-2195-4664-aac9-fd4a8210a5c8" {
    application_id = "d0d56978-5134-4e79-b6f9-88bb614f6b71"
    zone_id = "cf535477f63b2257ba5013a592477ca3"
    name = "Only Cloudflare Users"
    precedence = "1"
    decision = "allow"


    include = {


            email_domain =   ["cloudflare.com",]


    }



    exclude = {


            email =   ["wakka@zackattacktestpants.com",]


    }



    require = {


            ip =   ["127.0.0.1/32",]


    }


}
```