### PR TITLE
Resolves #13. Implements structured logging and verbose flag

### DIFF
--- a/internal/app/cf-terraforming/cmd/access_rule.go
+++ b/internal/app/cf-terraforming/cmd/access_rule.go
@@ -1,12 +1,11 @@
 package cmd
 
 import (
-	"fmt"
-	"log"
 	"os"
 	"text/template"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -30,10 +29,14 @@ var accessRuleCmd = &cobra.Command{
 	Use:   "access_rule",
 	Short: "Import Access Rule data into Terraform",
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Print("Importing Access Rule data")
+		log.Debug("Importing Access Rule data")
 
 		for _, zone := range zones {
-			log.Printf("[DEBUG] Processing zone: ID %s, Name %s", zone.ID, zone.Name)
+
+			log.WithFields(logrus.Fields{
+				"ID":   zone.ID,
+				"Name": zone.Name,
+			}).Debug("Processing zone")
 
 			totalPages := 999
 
@@ -41,14 +44,21 @@ var accessRuleCmd = &cobra.Command{
 				accessRules, err := api.ListZoneAccessRules(zone.ID, cloudflare.AccessRule{}, page)
 
 				if err != nil {
-					fmt.Println(err)
+					log.Fatal(err)
 					os.Exit(1)
 				}
 
 				totalPages = accessRules.TotalPages
 
 				for _, r := range accessRules.Result {
-					log.Printf("[DEBUG] Access Rule ID %s, Notes %s, Configuration %s, Scope %s\n", r.ID, r.Notes, r.Configuration, r.Scope)
+
+					log.WithFields(logrus.Fields{
+						"Rule ID":       r.ID,
+						"Notes":         r.Notes,
+						"Configuration": r.Configuration,
+						"Scope":         r.Scope,
+					}).Debug("Processing Access rule")
+
 					accessRuleParse(zone, r)
 				}
 			}

--- a/internal/app/cf-terraforming/cmd/account_member.go
+++ b/internal/app/cf-terraforming/cmd/account_member.go
@@ -1,14 +1,14 @@
 package cmd
 
 import (
-	"fmt"
-	"log"
 	"os"
 
 	"text/template"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/spf13/cobra"
+
+	"github.com/sirupsen/logrus"
 )
 
 const accountMemberTemplate = `
@@ -26,10 +26,10 @@ var accountMemberCmd = &cobra.Command{
 	Use:   "account_member",
 	Short: "Import Account Member data into Terraform",
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Print("Importing Account Member data")
+		log.Debug("Importing Account Member data")
 
 		if accountID == "" {
-			fmt.Println("'account' must be set.")
+			log.Fatal("'account' must be set.")
 			os.Exit(1)
 		}
 
@@ -39,12 +39,18 @@ var accountMemberCmd = &cobra.Command{
 		})
 
 		if err != nil {
-			fmt.Println(err)
+			log.Fatal(err)
 			os.Exit(1)
 		}
 
 		for _, r := range accountMembers {
-			log.Printf("[DEBUG] Account Member ID %s, Status %s, User.ID %s, User.Email %s\n", r.ID, r.Status, r.User.ID, r.User.Email)
+			log.WithFields(logrus.Fields{
+				"Account member ID": r.ID,
+				"Status":            r.Status,
+				"User ID":           r.User.ID,
+				"User email":        r.User.Email,
+			}).Debug("Processing account member")
+
 			memberParse(r)
 		}
 	},

--- a/internal/app/cf-terraforming/cmd/custom_pages.go
+++ b/internal/app/cf-terraforming/cmd/custom_pages.go
@@ -1,12 +1,11 @@
 package cmd
 
 import (
-	"fmt"
-	"log"
 	"os"
 	"text/template"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -30,17 +29,27 @@ var customPagesCmd = &cobra.Command{
 		log.Print("Importing Custom Pages data")
 
 		for _, zone := range zones {
-			log.Printf("[DEBUG] Processing zone: ID %s, Name %s", zone.ID, zone.Name)
+
+			log.WithFields(logrus.Fields{
+				"ID":   zone.ID,
+				"Name": zone.Name,
+			}).Debug("Processing zone")
 
 			customPages, err := api.CustomPages(&cloudflare.CustomPageOptions{ZoneID: zone.ID})
 
 			if err != nil {
-				fmt.Println(err)
+				log.Fatal(err)
 				os.Exit(1)
 			}
 
 			for _, r := range customPages {
-				log.Printf("[DEBUG] Custom Page ID %s, URL %s, Description %s\n", r.ID, r.URL, r.Description)
+
+				log.WithFields(logrus.Fields{
+					"ID":          r.ID,
+					"URL":         r.URL,
+					"Description": r.Description,
+				}).Debug("Processing custom page")
+
 				customPagesParse(zone, r)
 			}
 		}

--- a/internal/app/cf-terraforming/cmd/filter.go
+++ b/internal/app/cf-terraforming/cmd/filter.go
@@ -1,12 +1,11 @@
 package cmd
 
 import (
-	"fmt"
-	"log"
 	"os"
 	"text/template"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -28,10 +27,14 @@ var filterCmd = &cobra.Command{
 	Use:   "filter",
 	Short: "Import Filter data into Terraform",
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Print("Importing Filter data")
+		log.Debug("Importing Filter data")
 
 		for _, zone := range zones {
-			log.Printf("[DEBUG] Processing zone: ID %s, Name %s", zone.ID, zone.Name)
+
+			log.WithFields(logrus.Fields{
+				"ID":   zone.ID,
+				"Name": zone.Name,
+			}).Debug("Processing zone")
 
 			filters, err := api.Filters(zone.ID, cloudflare.PaginationOptions{
 				Page:    1,
@@ -39,12 +42,18 @@ var filterCmd = &cobra.Command{
 			})
 
 			if err != nil {
-				fmt.Println(err)
+				log.Fatal(err)
 				os.Exit(1)
 			}
 
 			for _, r := range filters {
-				log.Printf("[DEBUG] Filter ID %s, Expression %s, Description %s\n", r.ID, r.Expression, r.Description)
+
+				log.WithFields(logrus.Fields{
+					"ID":          r.ID,
+					"Expression":  r.Expression,
+					"Description": r.Description,
+				})
+
 				filterParse(zone, r)
 			}
 		}

--- a/internal/app/cf-terraforming/cmd/firewall_rule.go
+++ b/internal/app/cf-terraforming/cmd/firewall_rule.go
@@ -2,12 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"text/template"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -30,10 +30,14 @@ var firewallRuleCmd = &cobra.Command{
 	Use:   "firewall_rule",
 	Short: "Import Firewall Rule data into Terraform",
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Print("Importing Firewall Rule data")
+		log.Debug("Importing Firewall Rule data")
 
 		for _, zone := range zones {
-			log.Printf("[DEBUG] Processing zone: ID %s, Name %s", zone.ID, zone.Name)
+
+			log.WithFields(logrus.Fields{
+				"ID":   zone.ID,
+				"Name": zone.Name,
+			}).Debug("Processing zone")
 
 			firewallRules, err := api.FirewallRules(zone.ID, cloudflare.PaginationOptions{
 				Page:    1,
@@ -46,7 +50,12 @@ var firewallRuleCmd = &cobra.Command{
 			}
 
 			for _, r := range firewallRules {
-				log.Printf("[DEBUG] Firewall Rule ID %s, Description %s\n", r.ID, r.Description)
+
+				log.WithFields(logrus.Fields{
+					"ID":          r.ID,
+					"Description": r.Description,
+				}).Debug("Processing firewall rule")
+
 				firewallRuleParse(zone, r)
 			}
 		}

--- a/internal/app/cf-terraforming/cmd/load_balancer.go
+++ b/internal/app/cf-terraforming/cmd/load_balancer.go
@@ -1,13 +1,13 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
 
 	"text/template"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -63,17 +63,31 @@ var loadBalancerCmd = &cobra.Command{
 	Use:   "load_balancer",
 	Short: "Import a load balancer into Terraform",
 	Run: func(cmd *cobra.Command, args []string) {
+		log.Debug("Importing Load Balancer data")
 		// Loop through all zones in account and fetch routes for each zone
 		for _, zone := range zones {
 			loadBalancers, err := api.ListLoadBalancers(zone.ID)
 
+			log.WithFields(logrus.Fields{
+				"ID":   zone.ID,
+				"Name": zone.Name,
+			})
+
 			if err != nil {
-				fmt.Println(err)
+				log.Fatal(err)
 				os.Exit(1)
 			}
 
 			if len(loadBalancers) > 0 {
 				for _, lb := range loadBalancers {
+
+					log.WithFields(logrus.Fields{
+						"ID":           lb.ID,
+						"Description":  lb.Description,
+						"FallbackPool": lb.FallbackPool,
+						"DefaultPools": lb.DefaultPools,
+					}).Debug("Processing load balancer")
+
 					loadBalancerParse(lb, zone)
 				}
 			}

--- a/internal/app/cf-terraforming/cmd/load_balancer_pool.go
+++ b/internal/app/cf-terraforming/cmd/load_balancer_pool.go
@@ -1,13 +1,13 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
 
 	"text/template"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -54,21 +54,26 @@ var loadBalancerPoolCmd = &cobra.Command{
 		loadBalancerPools, err := api.ListLoadBalancerPools()
 
 		if err != nil {
-			fmt.Println(err)
+			log.Fatal(err)
 			os.Exit(1)
 		}
 
 		if len(loadBalancerPools) > 0 {
 			for _, lbp := range loadBalancerPools {
+
+				log.WithFields(logrus.Fields{
+					"ID":          lbp.ID,
+					"Description": lbp.Description,
+				}).Debug("Processing load balancer pool")
+
 				loadBalancerPoolParse(lbp)
 			}
 		}
-
 	},
 }
 
 func loadBalancerPoolParse(lbp cloudflare.LoadBalancerPool) {
-	tmpl := template.Must(template.New("script").Funcs(templateFuncMap).Parse(loadBalancerPoolTemplate))
+	tmpl := template.Must(template.New("load_balancer_pool").Funcs(templateFuncMap).Parse(loadBalancerPoolTemplate))
 	tmpl.Execute(os.Stdout,
 		struct {
 			LBP cloudflare.LoadBalancerPool

--- a/internal/app/cf-terraforming/cmd/page_rule.go
+++ b/internal/app/cf-terraforming/cmd/page_rule.go
@@ -1,13 +1,12 @@
 package cmd
 
 import (
-	"fmt"
-	"log"
 	"os"
 
 	"text/template"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -40,19 +39,30 @@ var pageRuleCmd = &cobra.Command{
 	Use:   "page_rule",
 	Short: "Import Page Rule data into Terraform",
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Print("Importing Page Rule data")
+		log.Debug("Importing Page Rule data")
 
 		for _, zone := range zones {
-			log.Printf("[DEBUG] Processing zone: ID %s, Name %s", zone.ID, zone.Name)
+
+			log.WithFields(logrus.Fields{
+				"ID":   zone.ID,
+				"Name": zone.Name,
+			}).Debug("Processing zone")
 
 			pageRules, err := api.ListPageRules(zone.ID)
 
 			if err != nil {
-				fmt.Println(err)
+				log.Fatal(err)
 				os.Exit(1)
 			}
 
 			for _, rule := range pageRules {
+
+				log.WithFields(logrus.Fields{
+					"ID":       rule.ID,
+					"Targets":  rule.Targets,
+					"Priority": rule.Priority,
+					"Status":   rule.Status,
+				}).Debug("Processing page rule")
 
 				pageRuleParse(rule, zone)
 			}

--- a/internal/app/cf-terraforming/cmd/waf_rule.go
+++ b/internal/app/cf-terraforming/cmd/waf_rule.go
@@ -2,12 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"text/template"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -27,33 +27,44 @@ var wafRuleCmd = &cobra.Command{
 	Use:   "waf_rule",
 	Short: "Import WAF Rule data into Terraform",
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Print("Importing WAF Rule data")
+		log.Debug("Importing WAF Rule data")
 
 		for _, zone := range zones {
-			log.Printf("[DEBUG] Processing zone: ID %s, Name %s", zone.ID, zone.Name)
 
-			log.Printf("[DEBUG] Get WAF Packages")
+			log.WithFields(logrus.Fields{
+				"ID":   zone.ID,
+				"Name": zone.Name,
+			}).Debug("Processing zone")
 
 			wafPackages, err := api.ListWAFPackages(zone.ID)
 
 			if err != nil {
-				fmt.Println(err)
+				log.Fatal(err)
 				os.Exit(1)
 			}
 
 			for _, wafPackage := range wafPackages {
-				log.Printf("[DEBUG] WAF Package ID %s, Name %s\n", wafPackage.ID, wafPackage.Name)
-				log.Printf("[DEBUG] Get WAF Rules in a Package")
+
+				log.WithFields(logrus.Fields{
+					"ID":   wafPackage.ID,
+					"Name": wafPackage.Name,
+				}).Debug("Processing WAF package")
+
+				log.Debug("Fetching WAF rules")
 
 				wafRules, err := api.ListWAFRules(zone.ID, wafPackage.ID)
 
 				if err != nil {
-					fmt.Println(err)
+					log.Fatal(err)
 					os.Exit(1)
 				}
 
 				for _, rule := range wafRules {
-					log.Printf("[DEBUG] Processing WAF Rule: ID %s, Description %s", rule.ID, rule.Description)
+
+					log.WithFields(logrus.Fields{
+						"ID": rule.ID,
+					}).Debug("Processing WAF rule")
+
 					wafRuleParse(zone, wafPackage, rule)
 				}
 			}

--- a/internal/app/cf-terraforming/cmd/worker_route.go
+++ b/internal/app/cf-terraforming/cmd/worker_route.go
@@ -1,13 +1,13 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
 
 	"text/template"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -31,17 +31,23 @@ var workerRouteCmd = &cobra.Command{
 	Use:   "worker_route",
 	Short: "Import a worker route into Terraform",
 	Run: func(cmd *cobra.Command, args []string) {
+		log.Debug("Importing worker route data")
 		// Loop through all zones in account and fetch routes for each zone
 		for _, zone := range zones {
 			workerRoutesResponse, err := api.ListWorkerRoutes(zone.ID)
 
 			if err != nil {
-				fmt.Println(err)
+				log.Fatal(err)
 				os.Exit(1)
 			}
 
 			if workerRoutesResponse.Success == true {
 				for _, route := range workerRoutesResponse.Routes {
+
+					log.WithFields(logrus.Fields{
+						"ID":      route.ID,
+						"Pattern": route.Pattern,
+					}).Debug("Processing woker route")
 					// worker_route is rendered differently for multi-script (enterprise) accounts
 					// and non-enterprise accounts
 					workerRouteParse(zone, route, api.OrganizationID != "")

--- a/internal/app/cf-terraforming/cmd/zone.go
+++ b/internal/app/cf-terraforming/cmd/zone.go
@@ -1,13 +1,12 @@
 package cmd
 
 import (
-	"fmt"
-	"log"
 	"os"
 
 	"text/template"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -44,17 +43,20 @@ var zoneCmd = &cobra.Command{
 	Use:   "zone",
 	Short: "Import zone data into Terraform",
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Print("Importing zones' data")
+		log.Debug("Importing zone data")
 
 		for _, zone := range zones {
 			zoneDetails, err := api.ZoneDetails(zone.ID)
 
 			if err != nil {
-				fmt.Println(err)
+				log.Fatal(err)
 				os.Exit(1)
 			}
 
-			log.Printf("[DEBUG] Processing zone: ID %s, Name %s", zoneDetails.ID, zoneDetails.Name)
+			log.WithFields(logrus.Fields{
+				"ID":   zoneDetails.ID,
+				"Name": zoneDetails.Name,
+			}).Debug("Processing zone")
 
 			zoneParse(zone)
 		}

--- a/internal/app/cf-terraforming/cmd/zone_lockdown.go
+++ b/internal/app/cf-terraforming/cmd/zone_lockdown.go
@@ -2,12 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"text/template"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -39,10 +39,13 @@ var zoneLockdownCmd = &cobra.Command{
 	Use:   "zone_lockdown",
 	Short: "Import Zone Lockdown data into Terraform",
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Print("Importing Zone Lockdown data")
+		log.Debug("Importing Zone Lockdown data")
 
 		for _, zone := range zones {
-			log.Printf("[DEBUG] Processing zone: ID %s, Name %s", zone.ID, zone.Name)
+			log.WithFields(logrus.Fields{
+				"ID":   zone.ID,
+				"Name": zone.Name,
+			}).Debug("Processing zone")
 
 			totalPages := 999
 
@@ -57,11 +60,15 @@ var zoneLockdownCmd = &cobra.Command{
 				totalPages = lockdowns.TotalPages
 
 				for _, r := range lockdowns.Result {
-					log.Printf("[DEBUG] Lockdown ID %s, URL %s\n", r.ID, r.URLs)
+
+					log.WithFields(logrus.Fields{
+						"ID":  r.ID,
+						"URL": r.URLs,
+					}).Debug("Processing lockdown")
+
 					zoneLockdownParse(zone, r)
 				}
 			}
-
 		}
 	},
 }

--- a/internal/app/cf-terraforming/cmd/zone_settings_override.go
+++ b/internal/app/cf-terraforming/cmd/zone_settings_override.go
@@ -1,14 +1,13 @@
 package cmd
 
 import (
-	"fmt"
-	"log"
 	"os"
 
 	"text/template"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -45,16 +44,20 @@ var zoneSettingsOverrideCmd = &cobra.Command{
 	Use:   "zone_settings_override",
 	Short: "Import Zone Settings Override data into Terraform",
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Print("Importing Zone Settings data")
+		log.Debug("Importing zone settings data")
 
 		for _, zone := range zones {
 			// Fetch all settings for a zone
 			settingsResponse, err := api.ZoneSettings(zone.ID)
 
 			if err != nil {
-				fmt.Println(err)
+				log.Fatal(err)
 				os.Exit(1)
 			}
+
+			log.WithFields(logrus.Fields{
+				"Result": settingsResponse.Result,
+			}).Debug("Processing zone settings")
 
 			zoneSettingsOverrideParse(settingsResponse.Result, zone)
 		}


### PR DESCRIPTION
These changes implement structured logging and verbose mode, introducing two new optional flags: 

* -l (logging level)
* -v (verbose mode)

By default, if you pass neither of these flags, cf-terraforming will not log any error or info messages to stdout, so as to not pollute your generated terraform configuration files and to allow for clean redirects.

However, it can be useful when debugging issues to specify a logging level, like so: 
```
go run cmd/cf-terraforming/main.go --email $CLOUDFLARE_EMAIL --key $CLOUDFLARE_API_KEY -a 1233455678d876bc764b5f763af7644411 -l="info" spectrum_application
 
DEBU[0000] Initializing cloudflare-go                    API email=zproser@cloudflare.com Account ID=e9e138b6x52ea331b359a2ddfc6a8 Organization ID= Zone name=article-optimize.com
DEBU[0000] Selecting zones for import
DEBU[0000] Zones selected:
DEBU[0000] Zone                                          ID=81b06ss3228f488fh84e5e993c2dc17 Name=article-optimize.com
DEBU[0000] Importing zone settings data 
 ```
There are seven supported logging levels: 

* trace
* debug
* info
* warning
* error
* fatal 
* panic 

For convenience, the verbose flag is also available and can be used like so: 
```
go run cmd/cf-terraforming/main.go --email $CLOUDFLARE_EMAIL --key $CLOUDFLARE_API_KEY -a 1233d87642b6bc764b5f763af7675d11 -v spectrum_application
```
Note that passing the verbose flag is functionally equivalent to specifying a log level of debug