### PR TITLE
SDK-31 Implement load balancer monitor

### DIFF
--- a/internal/app/cf-terraforming/cmd/load_balancer_monitor.go
+++ b/internal/app/cf-terraforming/cmd/load_balancer_monitor.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	cloudflare "github.com/cloudflare/cloudflare-go"
+
+	"text/template"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+const loadBalancerMonitorTemplate = `
+resource "cloudflare_load_balancer_monitor" "{{.LBM.ID}}" {
+    expected_body = "{{.LBM.ExpectedBody}}"
+    expected_codes = "{{.LBM.ExpectedCodes}}"
+    method = "{{.LBM.Method}}"
+    timeout = {{.LBM.Timeout}}
+    path = "{{.LBM.Path}}"
+    interval = {{.LBM.Interval}}
+    retries = {{.LBM.Retries}}
+    description = "{{.LBM.Description}}"
+    {{if isMap .LBM.Header}}
+    header {
+    {{range $k, $v := .LBM.Header}}
+        {{$k}} = {{ quoteIfString $v }}
+    {{end}}
+    }
+    {{end}}
+}
+`
+
+func init() {
+	rootCmd.AddCommand(loadBalancerMonitorCmd)
+}
+
+var loadBalancerMonitorCmd = &cobra.Command{
+	Use:   "load_balancer_monitor",
+	Short: "Import a load balancer monitor into Terraform",
+	Run: func(cmd *cobra.Command, args []string) {
+		loadBalancerMonitors, err := api.ListLoadBalancerMonitors()
+
+		if err != nil {
+			log.Fatal(err)
+			os.Exit(1)
+		}
+
+		if len(loadBalancerMonitors) > 0 {
+			for _, lbm := range loadBalancerMonitors {
+
+				log.WithFields(logrus.Fields{
+					"ID":          lbm.ID,
+					"Description": lbm.Description,
+				}).Debug("Processing load balancer monitor")
+
+				loadBalancerMonitorParse(lbm)
+			}
+		}
+	},
+}
+
+func loadBalancerMonitorParse(lbm cloudflare.LoadBalancerMonitor) {
+	tmpl := template.Must(template.New("load_balancer_monitor").Funcs(templateFuncMap).Parse(loadBalancerMonitorTemplate))
+	tmpl.Execute(os.Stdout,
+		struct {
+			LBM cloudflare.LoadBalancerMonitor
+		}{
+			LBM: lbm,
+		})
+}

--- a/internal/app/cf-terraforming/cmd/load_balancer_monitor.go
+++ b/internal/app/cf-terraforming/cmd/load_balancer_monitor.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"


### PR DESCRIPTION
Implements support for exporting ```load_balancer_monitor``` as described [here](https://www.terraform.io/docs/providers/cloudflare/r/load_balancer_monitor.html).

**Usage**

```
go run cmd/cf-terraforming/main.go --email $CLOUDFLARE_EMAIL --key $CLOUDFLARE_API_KEY -z example.com -a sss8b652ea7cd44359a2d6678c60 load_balancer_monitor

resource "cloudflare_load_balancer_monitor" "b4ssgd7c5e17db692xxec5dbvvyvv022rc3" {
    expected_body = ""
    expected_codes = "200"
    method = "GET"
    timeout = 5
    path = "/"
    interval = 60
    retries = 2
    description = ""

    header {

    }
}
```