### PR TITLE
Export everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Overview
 
-cf-terraforming is a command line utility to facilitate terraforming your existing Cloudflare resources. It does this by using your account credentials to retrieve your configurations from the [Cloudflare API](https://api.cloudflare.com) and converting them to Terraform configurations that can be used with the [Terraform Cloudflare provider](https://www.terraform.io/docs/providers/cloudflare/index.html). 
+cf-terraforming is a command line utility to facilitate terraforming your existing Cloudflare resources. It does this by using your account credentials to retrieve your configurations from the [Cloudflare API](https://api.cloudflare.com) and converting them to Terraform configurations that can be used with the [Terraform Cloudflare provider](https://www.terraform.io/docs/providers/cloudflare/index.html).
 
 This tool is ideal if you already have Cloudflare resources defined but want to start managing them via Terraform, and don't want to spend the time to manually write the Terraform configuration to describe them.
 
@@ -18,6 +18,7 @@ Available Commands:
   access_policy          Import Access Policy data into Terraform
   access_rule            Import Access Rule data into Terraform
   account_member         Import Account Member data into Terraform
+  all                    Import all Cloudflare resources into Terraform
   custom_pages           Import Custom Pages data into Terraform
   filter                 Import Filter data into Terraform
   firewall_rule          Import Firewall Rule data into Terraform
@@ -55,7 +56,7 @@ Use "cf-terraforming [command] --help" for more information about a command.
 
 **A note on storing your credentials securely:** We recommend that you store your Cloudflare credentials (API key, email, account ID, etc) as environment variables as demonstrated below.
 
-You can use ```go run``` to build and execute the binary in a single command like so: 
+You can use ```go run``` to build and execute the binary in a single command like so:
 
 ```go run cmd/cf-terraforming/main.go --email $CLOUDFLARE_EMAIL --key $CLOUDFLARE_TOKEN --account $CLOUDFLARE_ACCOUNT_ID spectrum_application```
 
@@ -73,30 +74,37 @@ resource "cloudflare_spectrum_application" "1150bed3f45247b99f7db9696fffa17cbx9"
     origin_direct = [ "tcp://37.241.37.138:8000", ]
 }
 ```
+
 See the currently **supported resources** below.
 
+## Download all Cloudflare resources
+
+Use the **all** command to download everything and convert it into Terraform config.
+
+```go run cmd/cf-terraforming/main.go --email $CLOUDFLARE_EMAIL --key $CLOUDFLARE_TOKEN --account $CLOUDFLARE_ACCOUNT_ID all```
+
 ## Controlling output and verbose mode
-By default, cf-terraforming will not output any log type messages to stdout when run, so as to not pollute your generated Terraform config files and to allow you to cleanly redirect cf-terraforming output to existing Terraform configs. 
+By default, cf-terraforming will not output any log type messages to stdout when run, so as to not pollute your generated Terraform config files and to allow you to cleanly redirect cf-terraforming output to existing Terraform configs.
 
 However, it can be useful when debugging issues to specify a logging level, like so:
 
 ```
 go run cmd/cf-terraforming/main.go --email $CLOUDFLARE_EMAIL --key $CLOUDFLARE_TOKEN -a 1233455678d876bc764b5f763af7644411 -l="debug" spectrum_application
- 
+
 DEBU[0000] Initializing cloudflare-go                    API email=apicloudflare.com Account ID=e9e138b6x52ea331b359a2ddfc6a8 Organization ID= Zone name=example.com
 DEBU[0000] Selecting zones for import
 DEBU[0000] Zones selected:
 DEBU[0000] Zone                                          ID=81b06ss3228f488fh84e5e993c2dc17 Name=example.com
-DEBU[0000] Importing zone settings data 
+DEBU[0000] Importing zone settings data
 ```
 
-For convenience, you can set the verbose flag, which is functionally equivalent to setting a log level of debug: 
+For convenience, you can set the verbose flag, which is functionally equivalent to setting a log level of debug:
 
 ```
 go run cmd/cf-terraforming/main.go --email $CLOUDFLARE_EMAIL --key $CLOUDFLARE_TOKEN -a 1233455678d876bc764b5f763af7644411 -v spectrum_application
 ```
 
-## Prerequisites 
+## Prerequisites
 * A Cloudflare account with resources defined (e.g. a few zones, some load balancers, spectrum applications, etc)
 * A valid Cloudflare API key and sufficient permissions to access the resources you are requesting via the API
 * A working [installation of Go](https://golang.org/doc/install)
@@ -123,10 +131,10 @@ This will fetch the cf-terraforming tool as well as its dependencies, updating t
 * [page_rule](https://www.terraform.io/docs/providers/cloudflare/r/page_rule.html)
 * [rate_limit](https://www.terraform.io/docs/providers/cloudflare/r/rate_limit.html)
 * [record](https://www.terraform.io/docs/providers/cloudflare/r/record.html)
-* [spectrum_application](https://www.terraform.io/docs/providers/cloudflare/r/spectrum_application.html) 
+* [spectrum_application](https://www.terraform.io/docs/providers/cloudflare/r/spectrum_application.html)
 * [waf_rule](https://www.terraform.io/docs/providers/cloudflare/r/waf_rule.html)
 * [worker_route](https://www.terraform.io/docs/providers/cloudflare/r/worker_route.html)
 * [worker_script](https://www.terraform.io/docs/providers/cloudflare/r/worker_script.html)
-* [zone](https://www.terraform.io/docs/providers/cloudflare/r/zone.html) 
+* [zone](https://www.terraform.io/docs/providers/cloudflare/r/zone.html)
 * [zone_lockdown](https://www.terraform.io/docs/providers/cloudflare/r/zone_lockdown.html)
-* [zone_settings_override](https://www.terraform.io/docs/providers/cloudflare/r/zone_settings_override.html) 
+* [zone_settings_override](https://www.terraform.io/docs/providers/cloudflare/r/zone_settings_override.html)

--- a/internal/app/cf-terraforming/cmd/all.go
+++ b/internal/app/cf-terraforming/cmd/all.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(allCmd)
+}
+
+var allCmd = &cobra.Command{
+	Use:   "all",
+	Short: "Import all Cloudflare resources into Terraform",
+	Run: func(cmd *cobra.Command, args []string) {
+		log.Debug("Importing ALL Cloudflare resource data")
+
+		accessApplicationCmd.Run(cmd, args)
+
+		accessPolicyCmd.Run(cmd, args)
+
+		accessRuleCmd.Run(cmd, args)
+
+		accountMemberCmd.Run(cmd, args)
+
+		customPagesCmd.Run(cmd, args)
+
+		filterCmd.Run(cmd, args)
+
+		firewallRuleCmd.Run(cmd, args)
+
+		loadBalancerCmd.Run(cmd, args)
+
+		loadBalancerMonitorCmd.Run(cmd, args)
+
+		loadBalancerPoolCmd.Run(cmd, args)
+
+		pageRuleCmd.Run(cmd, args)
+
+		rateLimitCmd.Run(cmd, args)
+
+		recordCmd.Run(cmd, args)
+
+		spectrumApplicationCmd.Run(cmd, args)
+
+		wafRuleCmd.Run(cmd, args)
+
+		workerRouteCmd.Run(cmd, args)
+
+		workerScriptCmd.Run(cmd, args)
+
+		zoneCmd.Run(cmd, args)
+
+		zoneLockdownCmd.Run(cmd, args)
+
+		zoneSettingsOverrideCmd.Run(cmd, args)
+	},
+}


### PR DESCRIPTION
Implement **all** command, which downloads all currently supported resources from your Cloudflare account in one go, converting them to Terraform config.

**Usage:**

```
go run cmd/cf-terraforming/main.go --email $CLOUDFLARE_EMAIL --key $CLOUDFLARE_API_KEY -z example.com -a $CLOUDFLARE_ACCOUNT_ID  all
```