### PR TITLE
Inconsistent logging

### DIFF
--- a/internal/app/cf-terraforming/cmd/access_application.go
+++ b/internal/app/cf-terraforming/cmd/access_application.go
@@ -51,8 +51,7 @@ var accessApplicationCmd = &cobra.Command{
 					}).Info("Insufficient permissions to access zone")
 					continue
 				}
-				log.Fatal(err)
-				os.Exit(1)
+				log.Debug(err)
 			}
 
 			for _, app := range accessApplications {

--- a/internal/app/cf-terraforming/cmd/access_policy.go
+++ b/internal/app/cf-terraforming/cmd/access_policy.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"os"
-	"strings"
 
+	"strings"
 	"text/template"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
@@ -80,8 +80,8 @@ var accessPolicyCmd = &cobra.Command{
 			})
 
 			if appFetchErr != nil {
-				log.Fatal(appFetchErr)
-				os.Exit(1)
+				log.Debug(appFetchErr)
+				return
 			}
 
 			for _, app := range accessApplications {
@@ -98,9 +98,7 @@ var accessPolicyCmd = &cobra.Command{
 						}).Debug("Insufficient permissions for accessing zone")
 						continue
 					}
-
-					log.Fatal(err)
-					os.Exit(1)
+					log.Debug(err)
 				}
 
 				for _, policy := range accessPolicies {

--- a/internal/app/cf-terraforming/cmd/access_rule.go
+++ b/internal/app/cf-terraforming/cmd/access_rule.go
@@ -44,8 +44,7 @@ var accessRuleCmd = &cobra.Command{
 				accessRules, err := api.ListZoneAccessRules(zone.ID, cloudflare.AccessRule{}, page)
 
 				if err != nil {
-					log.Fatal(err)
-					os.Exit(1)
+					log.Debug(err)
 				}
 
 				totalPages = accessRules.TotalPages

--- a/internal/app/cf-terraforming/cmd/account_member.go
+++ b/internal/app/cf-terraforming/cmd/account_member.go
@@ -29,8 +29,7 @@ var accountMemberCmd = &cobra.Command{
 		log.Debug("Importing Account Member data")
 
 		if accountID == "" {
-			log.Fatal("'account' must be set.")
-			os.Exit(1)
+			log.Error("'account' must be set.")
 		}
 
 		accountMembers, _, err := api.AccountMembers(accountID, cloudflare.PaginationOptions{
@@ -39,11 +38,11 @@ var accountMemberCmd = &cobra.Command{
 		})
 
 		if err != nil {
-			log.Fatal(err)
-			os.Exit(1)
+			log.Debug(err)
 		}
 
 		for _, r := range accountMembers {
+
 			log.WithFields(logrus.Fields{
 				"Account member ID": r.ID,
 				"Status":            r.Status,

--- a/internal/app/cf-terraforming/cmd/custom_pages.go
+++ b/internal/app/cf-terraforming/cmd/custom_pages.go
@@ -38,8 +38,8 @@ var customPagesCmd = &cobra.Command{
 			customPages, err := api.CustomPages(&cloudflare.CustomPageOptions{ZoneID: zone.ID})
 
 			if err != nil {
-				log.Fatal(err)
-				os.Exit(1)
+				log.Debug(err)
+				return
 			}
 
 			for _, r := range customPages {

--- a/internal/app/cf-terraforming/cmd/custom_pages.go
+++ b/internal/app/cf-terraforming/cmd/custom_pages.go
@@ -26,7 +26,7 @@ var customPagesCmd = &cobra.Command{
 	Use:   "custom_pages",
 	Short: "Import Custom Pages data into Terraform",
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Print("Importing Custom Pages data")
+		log.Debug("Importing Custom Pages data")
 
 		for _, zone := range zones {
 

--- a/internal/app/cf-terraforming/cmd/filter.go
+++ b/internal/app/cf-terraforming/cmd/filter.go
@@ -42,8 +42,8 @@ var filterCmd = &cobra.Command{
 			})
 
 			if err != nil {
-				log.Fatal(err)
-				os.Exit(1)
+				log.Debug(err)
+				return
 			}
 
 			for _, r := range filters {

--- a/internal/app/cf-terraforming/cmd/firewall_rule.go
+++ b/internal/app/cf-terraforming/cmd/firewall_rule.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"text/template"
@@ -45,8 +44,8 @@ var firewallRuleCmd = &cobra.Command{
 			})
 
 			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
+				log.Debug(err)
+				return
 			}
 
 			for _, r := range firewallRules {

--- a/internal/app/cf-terraforming/cmd/load_balancer.go
+++ b/internal/app/cf-terraforming/cmd/load_balancer.go
@@ -74,8 +74,8 @@ var loadBalancerCmd = &cobra.Command{
 			})
 
 			if err != nil {
-				log.Fatal(err)
-				os.Exit(1)
+				log.Debug(err)
+				return
 			}
 
 			if len(loadBalancers) > 0 {

--- a/internal/app/cf-terraforming/cmd/load_balancer_monitor.go
+++ b/internal/app/cf-terraforming/cmd/load_balancer_monitor.go
@@ -42,8 +42,7 @@ var loadBalancerMonitorCmd = &cobra.Command{
 		loadBalancerMonitors, err := api.ListLoadBalancerMonitors()
 
 		if err != nil {
-			log.Fatal(err)
-			os.Exit(1)
+			log.Debug(err)
 		}
 
 		if len(loadBalancerMonitors) > 0 {

--- a/internal/app/cf-terraforming/cmd/load_balancer_pool.go
+++ b/internal/app/cf-terraforming/cmd/load_balancer_pool.go
@@ -54,8 +54,8 @@ var loadBalancerPoolCmd = &cobra.Command{
 		loadBalancerPools, err := api.ListLoadBalancerPools()
 
 		if err != nil {
-			log.Fatal(err)
-			os.Exit(1)
+			log.Debug(err)
+			return
 		}
 
 		if len(loadBalancerPools) > 0 {

--- a/internal/app/cf-terraforming/cmd/page_rule.go
+++ b/internal/app/cf-terraforming/cmd/page_rule.go
@@ -51,8 +51,8 @@ var pageRuleCmd = &cobra.Command{
 			pageRules, err := api.ListPageRules(zone.ID)
 
 			if err != nil {
-				log.Fatal(err)
-				os.Exit(1)
+				log.Debug(err)
+				return
 			}
 
 			for _, rule := range pageRules {

--- a/internal/app/cf-terraforming/cmd/rate_limit.go
+++ b/internal/app/cf-terraforming/cmd/rate_limit.go
@@ -75,8 +75,8 @@ var rateLimitCmd = &cobra.Command{
 				})
 
 				if err != nil {
-					log.Fatal(err)
-					os.Exit(1)
+					log.Debug(err)
+					return
 				}
 
 				totalPages = resultInfo.TotalPages

--- a/internal/app/cf-terraforming/cmd/record.go
+++ b/internal/app/cf-terraforming/cmd/record.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"text/template"
 
@@ -66,8 +65,8 @@ var recordCmd = &cobra.Command{
 			recs, err := api.DNSRecords(zone.ID, cloudflare.DNSRecord{})
 
 			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
+				log.Debug(err)
+				return
 			}
 			for _, r := range recs {
 
@@ -86,7 +85,7 @@ var recordCmd = &cobra.Command{
 
 func recordParse(zone cloudflare.Zone, record cloudflare.DNSRecord) {
 	tmpl := template.Must(template.New("record").Funcs(templateFuncMap).Parse(recordTemplate))
-	if err := tmpl.Execute(os.Stdout,
+	tmpl.Execute(os.Stdout,
 		struct {
 			Zone             cloudflare.Zone
 			Record           cloudflare.DNSRecord
@@ -97,8 +96,5 @@ func recordParse(zone cloudflare.Zone, record cloudflare.DNSRecord) {
 			Record:           record,
 			IsValueTypeField: contains(dnsTypeValueFields, record.Type),
 			IsDataTypeField:  contains(dnsTypeDataFields, record.Type),
-		}); err != nil {
-		log.Fatal(err)
-		os.Exit(1)
-	}
+		})
 }

--- a/internal/app/cf-terraforming/cmd/spectrum_application.go
+++ b/internal/app/cf-terraforming/cmd/spectrum_application.go
@@ -60,6 +60,7 @@ var spectrumApplicationCmd = &cobra.Command{
 					}).Debug("Insufficient permissions for accessing zone")
 					continue
 				}
+				log.Debug(err)
 			}
 
 			if len(spectrumApplications) > 0 {

--- a/internal/app/cf-terraforming/cmd/waf_rule.go
+++ b/internal/app/cf-terraforming/cmd/waf_rule.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"text/template"
@@ -39,8 +38,8 @@ var wafRuleCmd = &cobra.Command{
 			wafPackages, err := api.ListWAFPackages(zone.ID)
 
 			if err != nil {
-				log.Fatal(err)
-				os.Exit(1)
+				log.Debug(err)
+				return
 			}
 
 			for _, wafPackage := range wafPackages {
@@ -55,8 +54,8 @@ var wafRuleCmd = &cobra.Command{
 				wafRules, err := api.ListWAFRules(zone.ID, wafPackage.ID)
 
 				if err != nil {
-					log.Fatal(err)
-					os.Exit(1)
+					log.Debug(err)
+					return
 				}
 
 				for _, rule := range wafRules {
@@ -74,7 +73,7 @@ var wafRuleCmd = &cobra.Command{
 
 func wafRuleParse(zone cloudflare.Zone, wafPackage cloudflare.WAFPackage, wafRule cloudflare.WAFRule) {
 	tmpl := template.Must(template.New("waf_rule").Funcs(templateFuncMap).Parse(wafRuleTemplate))
-	if err := tmpl.Execute(os.Stdout,
+	tmpl.Execute(os.Stdout,
 		struct {
 			Zone    cloudflare.Zone
 			Package cloudflare.WAFPackage
@@ -83,8 +82,5 @@ func wafRuleParse(zone cloudflare.Zone, wafPackage cloudflare.WAFPackage, wafRul
 			Zone:    zone,
 			Package: wafPackage,
 			Rule:    wafRule,
-		}); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
+		})
 }

--- a/internal/app/cf-terraforming/cmd/worker_route.go
+++ b/internal/app/cf-terraforming/cmd/worker_route.go
@@ -37,8 +37,8 @@ var workerRouteCmd = &cobra.Command{
 			workerRoutesResponse, err := api.ListWorkerRoutes(zone.ID)
 
 			if err != nil {
-				log.Fatal(err)
-				os.Exit(1)
+				log.Debug(err)
+				return
 			}
 
 			if workerRoutesResponse.Success == true {

--- a/internal/app/cf-terraforming/cmd/zone.go
+++ b/internal/app/cf-terraforming/cmd/zone.go
@@ -49,8 +49,8 @@ var zoneCmd = &cobra.Command{
 			zoneDetails, err := api.ZoneDetails(zone.ID)
 
 			if err != nil {
-				log.Fatal(err)
-				os.Exit(1)
+				log.Debug(err)
+				return
 			}
 
 			log.WithFields(logrus.Fields{

--- a/internal/app/cf-terraforming/cmd/zone_lockdown.go
+++ b/internal/app/cf-terraforming/cmd/zone_lockdown.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"text/template"
@@ -42,6 +41,7 @@ var zoneLockdownCmd = &cobra.Command{
 		log.Debug("Importing Zone Lockdown data")
 
 		for _, zone := range zones {
+
 			log.WithFields(logrus.Fields{
 				"ID":   zone.ID,
 				"Name": zone.Name,
@@ -53,8 +53,8 @@ var zoneLockdownCmd = &cobra.Command{
 				lockdowns, err := api.ListZoneLockdowns(zone.ID, page)
 
 				if err != nil {
-					fmt.Println(err)
-					os.Exit(1)
+					log.Debug(err)
+					return
 				}
 
 				totalPages = lockdowns.TotalPages
@@ -75,15 +75,12 @@ var zoneLockdownCmd = &cobra.Command{
 
 func zoneLockdownParse(zone cloudflare.Zone, lockdown cloudflare.ZoneLockdown) {
 	tmpl := template.Must(template.New("zone_lockdown").Funcs(templateFuncMap).Parse(zoneLockdownTemplate))
-	if err := tmpl.Execute(os.Stdout,
+	tmpl.Execute(os.Stdout,
 		struct {
 			Zone     cloudflare.Zone
 			Lockdown cloudflare.ZoneLockdown
 		}{
 			Zone:     zone,
 			Lockdown: lockdown,
-		}); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
+		})
 }

--- a/internal/app/cf-terraforming/cmd/zone_settings_override.go
+++ b/internal/app/cf-terraforming/cmd/zone_settings_override.go
@@ -51,8 +51,8 @@ var zoneSettingsOverrideCmd = &cobra.Command{
 			settingsResponse, err := api.ZoneSettings(zone.ID)
 
 			if err != nil {
-				log.Fatal(err)
-				os.Exit(1)
+				log.Debug(err)
+				return
 			}
 
 			log.WithFields(logrus.Fields{


### PR DESCRIPTION
Make logging more consistent across commands. Default to Debug level logging so that errors are only shown when run in verbose mode - otherwise the resource is silently excluded from output.