### PR TITLE
Convert empty interface's null value to empty string in templates

### DIFF
--- a/internal/app/cf-terraforming/cmd/util.go
+++ b/internal/app/cf-terraforming/cmd/util.go
@@ -26,6 +26,10 @@ func isMap(i interface{}) bool {
 }
 
 func quoteIfString(i interface{}) interface{} {
+	// Handle <no value> zero value by converting it to an empty string
+	if i == nil {
+		return "\"\""
+	}
 	if reflect.ValueOf(i).Kind() == reflect.String {
 		return fmt.Sprintf("\"%v\"", i)
 	} else {


### PR DESCRIPTION
Convert the "zero" value for an empty interface to an empty string within the context of our cf-terraforming templates.