### PR TITLE
viper: add BindEnv() for CLOUDFLARE_EMAIL and CLOUDFLARE_TOKEN

### DIFF
--- a/internal/app/cf-terraforming/cmd/root.go
+++ b/internal/app/cf-terraforming/cmd/root.go
@@ -70,7 +70,9 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&tfstate, "tfstate", "s", false, "Export tfstate for the given resource instead of HCL Terraform config (default)")
 
 	viper.BindPFlag("email", rootCmd.PersistentFlags().Lookup("email"))
+	viper.BindEnv("email", "CLOUDFLARE_EMAIL")
 	viper.BindPFlag("key", rootCmd.PersistentFlags().Lookup("key"))
+	viper.BindEnv("key", "CLOUDFLARE_TOKEN")
 	viper.BindPFlag("organization", rootCmd.PersistentFlags().Lookup("organization"))
 }
 

--- a/internal/app/cf-terraforming/cmd/root.go
+++ b/internal/app/cf-terraforming/cmd/root.go
@@ -72,7 +72,7 @@ func init() {
 	viper.BindPFlag("email", rootCmd.PersistentFlags().Lookup("email"))
 	viper.BindEnv("email", "CLOUDFLARE_EMAIL")
 	viper.BindPFlag("key", rootCmd.PersistentFlags().Lookup("key"))
-	viper.BindEnv("key", "CLOUDFLARE_TOKEN")
+	viper.BindEnv("key", "CLOUDFLARE_KEY")
 	viper.BindPFlag("organization", rootCmd.PersistentFlags().Lookup("organization"))
 }
 


### PR DESCRIPTION
It's now possible to use `cf-terraforming` with tools like [`direnv`](https://github.com/direnv/direnv)

```
$ env CLOUDFLARE_EMAIL="me@example.org" CLOUDFLARE_TOKEN="..." cf-terraforming zone -z example.com
```