### PR TITLE
Auth: Support API Tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Flags:
   -h, --help                  help for cf-terraforming
   -k, --key string            API Key generated on the 'My Profile' page. See: https://dash.cloudflare.com/?account=profile
   -l, --loglevel string       Specify logging level: (trace, debug, info, warn, error, fatal, panic)
-  -o, --organization string   Use specific organization ID for import
+  -o, --organization string   Use specific organization ID for import (deprecated, use -a instead)
   -s, --tfstate               Export tfstate for the given resource instead of HCL Terraform config (default ! See caveats below !)
   -v, --verbose               Specify verbose output (same as setting log level to debug)
   -z, --zone string           Limit the export to a single zone (name or ID)
@@ -126,7 +126,7 @@ Currently, only the worker_route command supports the --tfstate flag, but suppor
 To use this currently experimental feature, pass the --tfstate (-s) flag to your command like so:
 
 ```
-$ go run cmd/cf-terraforming/main.go --email $CLOUDFLARE_EMAIL --key $CLOUDFLARE_API_KEY -z example.com -a $CLOUDFLARE_ACCOUNT_ID --organization $CLOUDFLARE_ORG_ID --tfstate worker_route
+$ go run cmd/cf-terraforming/main.go --email $CLOUDFLARE_EMAIL --key $CLOUDFLARE_API_KEY -z example.com --account $CLOUDFLARE_ACCOUNT_ID --tfstate worker_route
 
 ```
 

--- a/internal/app/cf-terraforming/cmd/root.go
+++ b/internal/app/cf-terraforming/cmd/root.go
@@ -61,7 +61,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&apiToken, "token", "t", "", "API Token")
 
 	// [Optional] Organization ID
-	rootCmd.PersistentFlags().StringVarP(&orgID, "organization", "o", "", "Use specific organization ID for import")
+	rootCmd.PersistentFlags().StringVarP(&orgID, "organization", "o", "", "Use specific organization ID for import (deprecated)")
 
 	// Debug logging mode
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "loglevel", "l", "", "Specify logging level: (trace, debug, info, warn, error, fatal, panic)")
@@ -77,6 +77,7 @@ func init() {
 	viper.BindPFlag("token", rootCmd.PersistentFlags().Lookup("token"))
 	viper.BindEnv("token", "CLOUDFLARE_TOKEN")
 
+	viper.BindPFlag("account", rootCmd.PersistentFlags().Lookup("account"))
 	viper.BindPFlag("organization", rootCmd.PersistentFlags().Lookup("organization"))
 }
 
@@ -142,19 +143,19 @@ func persistentPreRun(cmd *cobra.Command, args []string) {
 	}
 
 	if apiToken = viper.GetString("token"); apiToken == "" {
-	if apiEmail = viper.GetString("email"); apiEmail == "" {
-		log.Error("'email' must be set.")
-	}
+		if apiEmail = viper.GetString("email"); apiEmail == "" {
+			log.Error("'email' must be set.")
+		}
 
-	if apiKey = viper.GetString("key"); apiKey == "" {
-		log.Error("'key' must be set.")
-	}
+		if apiKey = viper.GetString("key"); apiKey == "" {
+			log.Error("'key' must be set.")
+		}
 
-	log.WithFields(logrus.Fields{
+		log.WithFields(logrus.Fields{
 			"API email":  apiEmail,
 			"Zone name":  zoneName,
 			"Account ID": accountID,
-	}).Debug("Initializing cloudflare-go")
+		}).Debug("Initializing cloudflare-go")
 
 	} else {
 		log.WithFields(logrus.Fields{


### PR DESCRIPTION
- Allow to authenticate Cloudflare API with API Tokens, which is an alternative way to API Key.
- Mark --organization as deprecated

