### PR TITLE
zone: Add NameServers only if they are defined

### DIFF
--- a/internal/app/cf-terraforming/cmd/zone.go
+++ b/internal/app/cf-terraforming/cmd/zone.go
@@ -133,6 +133,12 @@ func zoneResourceStateBuild(zone cloudflare.Zone) Resource {
 	if len(zone.VanityNS) > 1 {
 		zoneAttributes.VanityNameServers1 = zone.VanityNS[0]
 	}
+	if len(zone.NameServers) > 0 {
+		zoneAttributes.NameServers0 = zone.NameServers[0]
+	}
+	if len(zone.NameServers) > 1 {
+		zoneAttributes.NameServers1 = zone.NameServers[1]
+	}
 	r.Primary.Attributes = zoneAttributes
 
 	return r


### PR DESCRIPTION
This is valid for zones with partial type

```
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/cloudflare/cf-terraforming/internal/app/cf-terraforming/cmd.zoneResourceStateBuild(0xc000168720, 0x20, 0xc000164fe0, 0xd, 0x0, 0xc0002b80c0, 0x3, 0x4, 0x0, 0x0, ...)
	/home/donatas/.go/src/github.com/cloudflare/cf-terraforming/internal/app/cf-terraforming/cmd/zone.go:111 +0x5a3
github.com/cloudflare/cf-terraforming/internal/app/cf-terraforming/cmd.glob..func20(0xd9f920, 0xc0001102a0, 0x0, 0x7)
	/home/donatas/.go/src/github.com/cloudflare/cf-terraforming/internal/app/cf-terraforming/cmd/zone.go:81 +0x37c
github.com/spf13/cobra.(*Command).execute(0xd9f920, 0xc000110230, 0x7, 0x7, 0xd9f920, 0xc000110230)
	/home/donatas/.go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:830 +0x2aa
github.com/spf13/cobra.(*Command).ExecuteC(0xda0320, 0x4072ef, 0xc000096058, 0x0)
	/home/donatas/.go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x2fb
github.com/spf13/cobra.(*Command).Execute(...)
	/home/donatas/.go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
github.com/cloudflare/cf-terraforming/internal/app/cf-terraforming/cmd.Execute()
	/home/donatas/.go/src/github.com/cloudflare/cf-terraforming/internal/app/cf-terraforming/cmd/root.go:38 +0x31
main.main()
	/home/donatas/.go/src/github.com/cloudflare/cf-terraforming/cmd/cf-terraforming/main.go:6 +0x20
```

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>