### PR TITLE
Fix for Issue #135

### DIFF
--- a/internal/app/cf-terraforming/cmd/worker_route.go
+++ b/internal/app/cf-terraforming/cmd/worker_route.go
@@ -17,7 +17,7 @@ resource "cloudflare_worker_route" "worker_route_{{.Route.ID}}" {
     zone = "{{.Zone.Name}}"
     pattern = "{{.Route.Pattern}}"
 {{if .MultiScript }}
-	script_name = "${cloudflare_worker_script.{{.Route.Script}}}"
+	script_name = "cloudflare_worker_script.{{.Route.Script}}"
 {{else}}
     enabled = "{{.Route.Enabled}}"
 {{end}}

--- a/internal/app/cf-terraforming/cmd/worker_route.go
+++ b/internal/app/cf-terraforming/cmd/worker_route.go
@@ -17,7 +17,7 @@ resource "cloudflare_worker_route" "worker_route_{{.Route.ID}}" {
     zone = "{{.Zone.Name}}"
     pattern = "{{.Route.Pattern}}"
 {{if .MultiScript }}
-	script_name = "cloudflare_worker_script.{{.Route.Script}}"
+	script_name = cloudflare_worker_script.{{.Route.Script}}
 {{else}}
     enabled = "{{.Route.Enabled}}"
 {{end}}


### PR DESCRIPTION
Removing the leading "${" and the closing "}" from the script_name key-value pair