### PR TITLE
Fix syntax for 'data' values

### DIFF
--- a/internal/app/cf-terraforming/cmd/record.go
+++ b/internal/app/cf-terraforming/cmd/record.go
@@ -30,7 +30,7 @@ resource "cloudflare_record" "{{.Record.Type}}_{{replace .Record.Name "." "_"}}_
     value = "{{.Record.Content}}"
 {{end}}
 {{ if .IsDataTypeField }}
-    data {
+    data = {
 {{range $k, $v := .Record.Data}}
         {{ $k }} = "{{ $v }}"
 {{end}}


### PR DESCRIPTION
The output for e.g. SRV, SSHFP records is currently missing an equals sign.

This causes the error:
```
Error: Unsupported block type

  on example.tf line 496, in resource "cloudflare_record" "SSHFP_example_123":
 496:     data {

Blocks of type "data" are not expected here. Did you mean to define argument "data"? If so, use the equals sign to assign it a value.
```

With this patch, the generated tf files now work correctly:
```
Success! The configuration is valid.
```

Thanks