### PR TITLE
Add support for CAA records

### DIFF
--- a/internal/app/cf-terraforming/cmd/record.go
+++ b/internal/app/cf-terraforming/cmd/record.go
@@ -105,7 +105,7 @@ var dnsTypeValueFields = []string{
 }
 
 var dnsTypeDataFields = []string{
-	"LOC", "SRV", "CERT", "DNSKEY", "DS", "NAPTR", "SMIMEA", "SSHFP", "TLSA", "URI",
+	"LOC", "SRV", "CAA", "CERT", "DNSKEY", "DS", "NAPTR", "SMIMEA", "SSHFP", "TLSA", "URI",
 }
 
 func init() {


### PR DESCRIPTION
Exported CAA records are currently missing their 'data' values. This fixes that

Fixes #55