### PR TITLE
Use same canonical form for record names as `terraform import`

### DIFF
--- a/internal/app/cf-terraforming/cmd/record.go
+++ b/internal/app/cf-terraforming/cmd/record.go
@@ -19,7 +19,7 @@ resource "cloudflare_record" "{{.Record.Type}}_{{replace .Record.Name "." "_"}}_
 {{ if .Zone.Paused}}
     paused = "true"
 {{end}}
-    name = "{{normalizeRecordName .Record.Name .Record.Domain}}"
+    name = "{{normalizeRecordName .Record.Name .Record.ZoneName}}"
     type = "{{.Record.Type}}"
     ttl = "{{.Record.TTL}}"
     proxied = "{{.Record.Proxied}}"

--- a/internal/app/cf-terraforming/cmd/record.go
+++ b/internal/app/cf-terraforming/cmd/record.go
@@ -196,7 +196,7 @@ func recordResourceStateBuild(zone cloudflare.Zone, record cloudflare.DNSRecord)
 				MetadataManagedByApps:       strconv.FormatBool(meta["managed_by_apps"].(bool)),
 				MetadataManagedByArgoTunnel: strconv.FormatBool(meta["managed_by_argo_tunnel"].(bool)),
 				ModifiedOn:                  record.ModifiedOn.Format(time.RFC3339),
-				Name:                        record.Name,
+				Name:                        util.normalizeRecordName(record.Name, record.ZoneName),
 				Priority:                    strconv.Itoa(record.Priority),
 				Proxiable:                   strconv.FormatBool(record.Proxiable),
 				Proxied:                     strconv.FormatBool(record.Proxied),

--- a/internal/app/cf-terraforming/cmd/record.go
+++ b/internal/app/cf-terraforming/cmd/record.go
@@ -19,7 +19,7 @@ resource "cloudflare_record" "{{.Record.Type}}_{{replace .Record.Name "." "_"}}_
 {{ if .Zone.Paused}}
     paused = "true"
 {{end}}
-    name = "{{.Record.Name}}"
+    name = "{{normalizeRecordName .Record.Name .Record.Domain}}"
     type = "{{.Record.Type}}"
     ttl = "{{.Record.TTL}}"
     proxied = "{{.Record.Proxied}}"

--- a/internal/app/cf-terraforming/cmd/util.go
+++ b/internal/app/cf-terraforming/cmd/util.go
@@ -41,10 +41,15 @@ func quoteIfString(i interface{}) interface{} {
 	}
 }
 
+func normalizeRecordName(name, domain string) string {
+	return strings.TrimSuffix(name, "."+domain)
+}
+
 var templateFuncMap = template.FuncMap{
 	"replace":       replace,
 	"isMap":         isMap,
 	"quoteIfString": quoteIfString,
+	"normalizeRecordName": normalizeRecordName,
 }
 
 func hashMap(values map[string]string) int {


### PR DESCRIPTION
This tool currently uses a slightly different naming scheme for records than the Cloudflare Terraform provider.

This tool uses FQDNs, e.g. `sub.foo.com`, whereas the other project expects just the subdomain, e.g. `sub`. (For apex records, e.g. `foo.com` itself, both tools output the whole domain name.)

This makes using `terraform import` annoying because the names don't match exactly and Terraform then wants to change all the records names in the zone for no reason (Cloudflare's API accepts either form).

This patch changes the output form to match the one used by the Cloudflare Terraform provider.