### PR TITLE
Fix Rate-limit template issues, and log more errors by default

### DIFF
--- a/internal/app/cf-terraforming/cmd/access_application.go
+++ b/internal/app/cf-terraforming/cmd/access_application.go
@@ -79,7 +79,7 @@ var accessApplicationCmd = &cobra.Command{
 
 func accessApplicationParse(app cloudflare.AccessApplication, zone cloudflare.Zone) {
 	tmpl := template.Must(template.New("access_rule").Funcs(templateFuncMap).Parse(accessApplicationTemplate))
-	tmpl.Execute(os.Stdout,
+	err := tmpl.Execute(os.Stdout,
 		struct {
 			App  cloudflare.AccessApplication
 			Zone cloudflare.Zone
@@ -87,6 +87,9 @@ func accessApplicationParse(app cloudflare.AccessApplication, zone cloudflare.Zo
 			App:  app,
 			Zone: zone,
 		})
+	if err != nil {
+		log.Error(err)
+	}
 }
 
 func accessApplicationResourceStateBuild(app cloudflare.AccessApplication, zone cloudflare.Zone) Resource {

--- a/internal/app/cf-terraforming/cmd/access_application.go
+++ b/internal/app/cf-terraforming/cmd/access_application.go
@@ -57,10 +57,10 @@ var accessApplicationCmd = &cobra.Command{
 
 					log.WithFields(logrus.Fields{
 						"ID": zone.ID,
-					}).Info("Insufficient permissions to access zone")
+					}).Error("Insufficient permissions to access zone")
 					continue
 				}
-				log.Debug(err)
+				log.Error(err)
 			}
 
 			for _, app := range accessApplications {

--- a/internal/app/cf-terraforming/cmd/access_policy.go
+++ b/internal/app/cf-terraforming/cmd/access_policy.go
@@ -122,7 +122,7 @@ var accessPolicyCmd = &cobra.Command{
 
 func accessPolicyParse(app cloudflare.AccessApplication, policy cloudflare.AccessPolicy, zone cloudflare.Zone) {
 	tmpl := template.Must(template.New("access_policy").Funcs(templateFuncMap).Parse(accessPolicyTemplate))
-	tmpl.Execute(os.Stdout,
+	err := tmpl.Execute(os.Stdout,
 		struct {
 			App    cloudflare.AccessApplication
 			Policy cloudflare.AccessPolicy
@@ -132,6 +132,9 @@ func accessPolicyParse(app cloudflare.AccessApplication, policy cloudflare.Acces
 			Policy: policy,
 			Zone:   zone,
 		})
+	if err != nil {
+		log.Error(err)
+	}
 }
 
 func accessPolicyResourceStateBuild(app cloudflare.AccessApplication, policy cloudflare.AccessPolicy, zone cloudflare.Zone) Resource {

--- a/internal/app/cf-terraforming/cmd/access_policy.go
+++ b/internal/app/cf-terraforming/cmd/access_policy.go
@@ -85,7 +85,7 @@ var accessPolicyCmd = &cobra.Command{
 			})
 
 			if appFetchErr != nil {
-				log.Debug(appFetchErr)
+				log.Error(appFetchErr)
 				return
 			}
 
@@ -100,10 +100,10 @@ var accessPolicyCmd = &cobra.Command{
 					if strings.Contains(err.Error(), "HTTP status 403") {
 						log.WithFields(logrus.Fields{
 							"ID": zone.ID,
-						}).Debug("Insufficient permissions for accessing zone")
+						}).Error("Insufficient permissions for accessing zone")
 						continue
 					}
-					log.Debug(err)
+					log.Error(err)
 				}
 
 				for _, policy := range accessPolicies {

--- a/internal/app/cf-terraforming/cmd/access_rule.go
+++ b/internal/app/cf-terraforming/cmd/access_rule.go
@@ -82,7 +82,7 @@ var accessRuleCmd = &cobra.Command{
 
 func accessRuleParse(zone cloudflare.Zone, accessRule cloudflare.AccessRule) {
 	tmpl := template.Must(template.New("access_rule").Funcs(templateFuncMap).Parse(accessRuleTemplate))
-	tmpl.Execute(os.Stdout,
+	err := tmpl.Execute(os.Stdout,
 		struct {
 			Zone       cloudflare.Zone
 			AccessRule cloudflare.AccessRule
@@ -90,6 +90,9 @@ func accessRuleParse(zone cloudflare.Zone, accessRule cloudflare.AccessRule) {
 			Zone:       zone,
 			AccessRule: accessRule,
 		})
+	if err != nil {
+		log.Error(err)
+	}
 }
 
 func accessRuleResourceStateBuild(zone cloudflare.Zone, rule cloudflare.AccessRule) Resource {

--- a/internal/app/cf-terraforming/cmd/access_rule.go
+++ b/internal/app/cf-terraforming/cmd/access_rule.go
@@ -54,7 +54,7 @@ var accessRuleCmd = &cobra.Command{
 				accessRules, err := api.ListZoneAccessRules(zone.ID, cloudflare.AccessRule{}, page)
 
 				if err != nil {
-					log.Debug(err)
+					log.Error(err)
 				}
 
 				totalPages = accessRules.TotalPages

--- a/internal/app/cf-terraforming/cmd/account_member.go
+++ b/internal/app/cf-terraforming/cmd/account_member.go
@@ -38,7 +38,7 @@ var accountMemberCmd = &cobra.Command{
 		})
 
 		if err != nil {
-			log.Debug(err)
+			log.Error(err)
 		}
 
 		for _, r := range accountMembers {

--- a/internal/app/cf-terraforming/cmd/account_member.go
+++ b/internal/app/cf-terraforming/cmd/account_member.go
@@ -61,10 +61,13 @@ var accountMemberCmd = &cobra.Command{
 
 func memberParse(member cloudflare.AccountMember) {
 	tmpl := template.Must(template.New("script").Funcs(templateFuncMap).Parse(accountMemberTemplate))
-	tmpl.Execute(os.Stdout,
+	err := tmpl.Execute(os.Stdout,
 		struct {
 			Member cloudflare.AccountMember
 		}{
 			Member: member,
 		})
+	if err != nil {
+		log.Error(err)
+	}
 }

--- a/internal/app/cf-terraforming/cmd/custom_pages.go
+++ b/internal/app/cf-terraforming/cmd/custom_pages.go
@@ -38,7 +38,7 @@ var customPagesCmd = &cobra.Command{
 			customPages, err := api.CustomPages(&cloudflare.CustomPageOptions{ZoneID: zone.ID})
 
 			if err != nil {
-				log.Debug(err)
+				log.Error(err)
 				return
 			}
 

--- a/internal/app/cf-terraforming/cmd/custom_pages.go
+++ b/internal/app/cf-terraforming/cmd/custom_pages.go
@@ -62,7 +62,7 @@ var customPagesCmd = &cobra.Command{
 
 func customPagesParse(zone cloudflare.Zone, customPage cloudflare.CustomPage) {
 	tmpl := template.Must(template.New("custom_pages").Funcs(templateFuncMap).Parse(customPagesTemplate))
-	tmpl.Execute(os.Stdout,
+	err := tmpl.Execute(os.Stdout,
 		struct {
 			Zone       cloudflare.Zone
 			CustomPage cloudflare.CustomPage
@@ -70,4 +70,7 @@ func customPagesParse(zone cloudflare.Zone, customPage cloudflare.CustomPage) {
 			Zone:       zone,
 			CustomPage: customPage,
 		})
+	if err != nil {
+		log.Error(err)
+	}
 }

--- a/internal/app/cf-terraforming/cmd/filter.go
+++ b/internal/app/cf-terraforming/cmd/filter.go
@@ -52,7 +52,7 @@ var filterCmd = &cobra.Command{
 			})
 
 			if err != nil {
-				log.Debug(err)
+				log.Error(err)
 				return
 			}
 

--- a/internal/app/cf-terraforming/cmd/filter.go
+++ b/internal/app/cf-terraforming/cmd/filter.go
@@ -77,7 +77,7 @@ var filterCmd = &cobra.Command{
 
 func filterParse(zone cloudflare.Zone, filter cloudflare.Filter) {
 	tmpl := template.Must(template.New("filter").Funcs(templateFuncMap).Parse(filterTemplate))
-	tmpl.Execute(os.Stdout,
+	err := tmpl.Execute(os.Stdout,
 		struct {
 			Zone   cloudflare.Zone
 			Filter cloudflare.Filter
@@ -85,6 +85,9 @@ func filterParse(zone cloudflare.Zone, filter cloudflare.Filter) {
 			Zone:   zone,
 			Filter: filter,
 		})
+	if err != nil {
+		log.Error(err)
+	}
 }
 
 func filterResourceStateBuild(zone cloudflare.Zone, filter cloudflare.Filter) Resource {

--- a/internal/app/cf-terraforming/cmd/firewall_rule.go
+++ b/internal/app/cf-terraforming/cmd/firewall_rule.go
@@ -79,7 +79,7 @@ var firewallRuleCmd = &cobra.Command{
 
 func firewallRuleParse(zone cloudflare.Zone, firewallRule cloudflare.FirewallRule) {
 	tmpl := template.Must(template.New("firewall_rule").Funcs(templateFuncMap).Parse(firewallRuleTemplate))
-	tmpl.Execute(os.Stdout,
+	err := tmpl.Execute(os.Stdout,
 		struct {
 			Zone         cloudflare.Zone
 			FirewallRule cloudflare.FirewallRule
@@ -87,6 +87,9 @@ func firewallRuleParse(zone cloudflare.Zone, firewallRule cloudflare.FirewallRul
 			Zone:         zone,
 			FirewallRule: firewallRule,
 		})
+	if err != nil {
+		log.Error(err)
+	}
 }
 
 func firewallRuleResourceStateBuild(zone cloudflare.Zone, rule cloudflare.FirewallRule) Resource {

--- a/internal/app/cf-terraforming/cmd/firewall_rule.go
+++ b/internal/app/cf-terraforming/cmd/firewall_rule.go
@@ -55,7 +55,7 @@ var firewallRuleCmd = &cobra.Command{
 			})
 
 			if err != nil {
-				log.Debug(err)
+				log.Error(err)
 				return
 			}
 

--- a/internal/app/cf-terraforming/cmd/load_balancer.go
+++ b/internal/app/cf-terraforming/cmd/load_balancer.go
@@ -74,7 +74,7 @@ var loadBalancerCmd = &cobra.Command{
 			})
 
 			if err != nil {
-				log.Debug(err)
+				log.Error(err)
 				return
 			}
 

--- a/internal/app/cf-terraforming/cmd/load_balancer.go
+++ b/internal/app/cf-terraforming/cmd/load_balancer.go
@@ -101,7 +101,7 @@ var loadBalancerCmd = &cobra.Command{
 
 func loadBalancerParse(lb cloudflare.LoadBalancer, zone cloudflare.Zone) {
 	tmpl := template.Must(template.New("script").Funcs(templateFuncMap).Parse(loadBalancerTemplate))
-	tmpl.Execute(os.Stdout,
+	err := tmpl.Execute(os.Stdout,
 		struct {
 			LB   cloudflare.LoadBalancer
 			Zone cloudflare.Zone
@@ -109,4 +109,7 @@ func loadBalancerParse(lb cloudflare.LoadBalancer, zone cloudflare.Zone) {
 			LB:   lb,
 			Zone: zone,
 		})
+	if err != nil {
+		log.Error(err)
+	}
 }

--- a/internal/app/cf-terraforming/cmd/load_balancer_monitor.go
+++ b/internal/app/cf-terraforming/cmd/load_balancer_monitor.go
@@ -65,10 +65,13 @@ var loadBalancerMonitorCmd = &cobra.Command{
 
 func loadBalancerMonitorParse(lbm cloudflare.LoadBalancerMonitor) {
 	tmpl := template.Must(template.New("load_balancer_monitor").Funcs(templateFuncMap).Parse(loadBalancerMonitorTemplate))
-	tmpl.Execute(os.Stdout,
+	err := tmpl.Execute(os.Stdout,
 		struct {
 			LBM cloudflare.LoadBalancerMonitor
 		}{
 			LBM: lbm,
 		})
+	if err != nil {
+		log.Error(err)
+	}
 }

--- a/internal/app/cf-terraforming/cmd/load_balancer_monitor.go
+++ b/internal/app/cf-terraforming/cmd/load_balancer_monitor.go
@@ -42,7 +42,7 @@ var loadBalancerMonitorCmd = &cobra.Command{
 		loadBalancerMonitors, err := api.ListLoadBalancerMonitors()
 
 		if err != nil {
-			log.Debug(err)
+			log.Error(err)
 		}
 
 		if len(loadBalancerMonitors) > 0 {

--- a/internal/app/cf-terraforming/cmd/load_balancer_pool.go
+++ b/internal/app/cf-terraforming/cmd/load_balancer_pool.go
@@ -54,7 +54,7 @@ var loadBalancerPoolCmd = &cobra.Command{
 		loadBalancerPools, err := api.ListLoadBalancerPools()
 
 		if err != nil {
-			log.Debug(err)
+			log.Error(err)
 			return
 		}
 

--- a/internal/app/cf-terraforming/cmd/load_balancer_pool.go
+++ b/internal/app/cf-terraforming/cmd/load_balancer_pool.go
@@ -78,10 +78,13 @@ var loadBalancerPoolCmd = &cobra.Command{
 
 func loadBalancerPoolParse(lbp cloudflare.LoadBalancerPool) {
 	tmpl := template.Must(template.New("load_balancer_pool").Funcs(templateFuncMap).Parse(loadBalancerPoolTemplate))
-	tmpl.Execute(os.Stdout,
+	err := tmpl.Execute(os.Stdout,
 		struct {
 			LBP cloudflare.LoadBalancerPool
 		}{
 			LBP: lbp,
 		})
+	if err != nil {
+		log.Error(err)
+	}
 }

--- a/internal/app/cf-terraforming/cmd/page_rule.go
+++ b/internal/app/cf-terraforming/cmd/page_rule.go
@@ -79,7 +79,7 @@ var pageRuleCmd = &cobra.Command{
 
 func pageRuleParse(rule cloudflare.PageRule, zone cloudflare.Zone) {
 	tmpl := template.Must(template.New("page_rule").Funcs(templateFuncMap).Parse(pageRuleTemplate))
-	tmpl.Execute(os.Stdout,
+	err := tmpl.Execute(os.Stdout,
 		struct {
 			Rule cloudflare.PageRule
 			Zone cloudflare.Zone
@@ -87,4 +87,7 @@ func pageRuleParse(rule cloudflare.PageRule, zone cloudflare.Zone) {
 			Rule: rule,
 			Zone: zone,
 		})
+	if err != nil {
+		log.Error(err)
+	}
 }

--- a/internal/app/cf-terraforming/cmd/page_rule.go
+++ b/internal/app/cf-terraforming/cmd/page_rule.go
@@ -54,7 +54,7 @@ var pageRuleCmd = &cobra.Command{
 			pageRules, err := api.ListPageRules(zone.ID)
 
 			if err != nil {
-				log.Debug(err)
+				log.Error(err)
 				return
 			}
 

--- a/internal/app/cf-terraforming/cmd/rate_limit.go
+++ b/internal/app/cf-terraforming/cmd/rate_limit.go
@@ -106,7 +106,7 @@ var rateLimitCmd = &cobra.Command{
 
 func rateLimitParse(zone cloudflare.Zone, rateLimit cloudflare.RateLimit) {
 	tmpl := template.Must(template.New("rate_limit").Funcs(templateFuncMap).Parse(rateLimitTemplate))
-	tmpl.Execute(os.Stdout,
+	err := tmpl.Execute(os.Stdout,
 		struct {
 			Zone      cloudflare.Zone
 			RateLimit cloudflare.RateLimit
@@ -114,6 +114,9 @@ func rateLimitParse(zone cloudflare.Zone, rateLimit cloudflare.RateLimit) {
 			Zone:      zone,
 			RateLimit: rateLimit,
 		})
+	if err != nil {
+		log.Error(err)
+	}
 }
 
 func rateLimitResourceStateBuild(zone cloudflare.Zone, rateLimit cloudflare.RateLimit) Resource {

--- a/internal/app/cf-terraforming/cmd/rate_limit.go
+++ b/internal/app/cf-terraforming/cmd/rate_limit.go
@@ -78,7 +78,7 @@ var rateLimitCmd = &cobra.Command{
 				})
 
 				if err != nil {
-					log.Debug(err)
+					log.Error(err)
 					return
 				}
 

--- a/internal/app/cf-terraforming/cmd/rate_limit.go
+++ b/internal/app/cf-terraforming/cmd/rate_limit.go
@@ -39,7 +39,7 @@ resource "cloudflare_rate_limit" "{{replace .Zone.Name "." "_"}}_{{.RateLimit.ID
     }
     {{end}}
   }
-  {{if .RateLimit.Correlate.By}}
+  {{if .RateLimit.Correlate}}
   correlate {
     by = "{{.RateLimit.Correlate.By}}"
   }
@@ -47,7 +47,7 @@ resource "cloudflare_rate_limit" "{{replace .Zone.Name "." "_"}}_{{.RateLimit.ID
   disabled = {{.RateLimit.Disabled}}
   description = "{{.RateLimit.Description}}"
   {{if .RateLimit.Bypass}}
-  bypass_url_patterns = [{{range .RateLimit.Bypass.Value}}"{{.}}", {{end}}]
+  bypass_url_patterns = [{{range .RateLimit.Bypass}}"{{.Value}}", {{end}}]
   {{end}}
 }
 `

--- a/internal/app/cf-terraforming/cmd/record.go
+++ b/internal/app/cf-terraforming/cmd/record.go
@@ -155,7 +155,7 @@ var recordCmd = &cobra.Command{
 
 func recordParse(zone cloudflare.Zone, record cloudflare.DNSRecord) {
 	tmpl := template.Must(template.New("record").Funcs(templateFuncMap).Parse(recordTemplate))
-	tmpl.Execute(os.Stdout,
+	err := tmpl.Execute(os.Stdout,
 		struct {
 			Zone             cloudflare.Zone
 			Record           cloudflare.DNSRecord
@@ -167,6 +167,9 @@ func recordParse(zone cloudflare.Zone, record cloudflare.DNSRecord) {
 			IsValueTypeField: contains(dnsTypeValueFields, record.Type),
 			IsDataTypeField:  contains(dnsTypeDataFields, record.Type),
 		})
+	if err != nil {
+		log.Error(err)
+	}
 }
 
 func recordResourceStateBuild(zone cloudflare.Zone, record cloudflare.DNSRecord) Resource {

--- a/internal/app/cf-terraforming/cmd/record.go
+++ b/internal/app/cf-terraforming/cmd/record.go
@@ -129,7 +129,7 @@ var recordCmd = &cobra.Command{
 			recs, err := api.DNSRecords(zone.ID, cloudflare.DNSRecord{})
 
 			if err != nil {
-				log.Debug(err)
+				log.Error(err)
 				return
 			}
 			for _, r := range recs {

--- a/internal/app/cf-terraforming/cmd/root.go
+++ b/internal/app/cf-terraforming/cmd/root.go
@@ -36,7 +36,7 @@ all of their existing Cloudflare configuration into Terraform.`,
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		log.Debug(err)
+		log.Error(err)
 		return
 	}
 }
@@ -148,7 +148,7 @@ func persistentPreRun(cmd *cobra.Command, args []string) {
 		}
 
 		if apiKey = viper.GetString("key"); apiKey == "" {
-			log.Error("'key' must be set.")
+			log.Error("either -t/--token or -k/--key must be set.")
 		}
 
 		log.WithFields(logrus.Fields{

--- a/internal/app/cf-terraforming/cmd/spectrum_application.go
+++ b/internal/app/cf-terraforming/cmd/spectrum_application.go
@@ -84,7 +84,7 @@ var spectrumApplicationCmd = &cobra.Command{
 
 func spectrumAppParse(app cloudflare.SpectrumApplication, zone cloudflare.Zone) {
 	tmpl := template.Must(template.New("script").Funcs(templateFuncMap).Parse(spectrumApplicationTemplate))
-	tmpl.Execute(os.Stdout,
+	err := tmpl.Execute(os.Stdout,
 		struct {
 			Zone cloudflare.Zone
 			App cloudflare.SpectrumApplication
@@ -92,4 +92,7 @@ func spectrumAppParse(app cloudflare.SpectrumApplication, zone cloudflare.Zone) 
 			Zone: zone,
 			App: app,
 		})
+	if err != nil {
+		log.Error(err)
+	}
 }

--- a/internal/app/cf-terraforming/cmd/spectrum_application.go
+++ b/internal/app/cf-terraforming/cmd/spectrum_application.go
@@ -58,10 +58,10 @@ var spectrumApplicationCmd = &cobra.Command{
 				if strings.Contains(err.Error(), "HTTP status 403") {
 					log.WithFields(logrus.Fields{
 						"ID": zone.ID,
-					}).Debug("Insufficient permissions for accessing zone")
+					}).Error("Insufficient permissions for accessing zone")
 					continue
 				}
-				log.Debug(err)
+				log.Error(err)
 			}
 
 			if len(spectrumApplications) > 0 {

--- a/internal/app/cf-terraforming/cmd/waf_rule.go
+++ b/internal/app/cf-terraforming/cmd/waf_rule.go
@@ -77,7 +77,7 @@ var wafRuleCmd = &cobra.Command{
 
 func wafRuleParse(zone cloudflare.Zone, wafPackage cloudflare.WAFPackage, wafRule cloudflare.WAFRule) {
 	tmpl := template.Must(template.New("waf_rule").Funcs(templateFuncMap).Parse(wafRuleTemplate))
-	tmpl.Execute(os.Stdout,
+	err := tmpl.Execute(os.Stdout,
 		struct {
 			Zone    cloudflare.Zone
 			Package cloudflare.WAFPackage
@@ -87,4 +87,7 @@ func wafRuleParse(zone cloudflare.Zone, wafPackage cloudflare.WAFPackage, wafRul
 			Package: wafPackage,
 			Rule:    wafRule,
 		})
+	if err != nil {
+		log.Error(err)
+	}
 }

--- a/internal/app/cf-terraforming/cmd/waf_rule.go
+++ b/internal/app/cf-terraforming/cmd/waf_rule.go
@@ -38,7 +38,7 @@ var wafRuleCmd = &cobra.Command{
 			wafPackages, err := api.ListWAFPackages(zone.ID)
 
 			if err != nil {
-				log.Debug(err)
+				log.Error(err)
 				return
 			}
 
@@ -54,7 +54,7 @@ var wafRuleCmd = &cobra.Command{
 				wafRules, err := api.ListWAFRules(zone.ID, wafPackage.ID)
 
 				if err != nil {
-					log.Debug(err)
+					log.Error(err)
 					return
 				}
 

--- a/internal/app/cf-terraforming/cmd/worker_route.go
+++ b/internal/app/cf-terraforming/cmd/worker_route.go
@@ -48,7 +48,7 @@ var workerRouteCmd = &cobra.Command{
 			workerRoutesResponse, err := api.ListWorkerRoutes(zone.ID)
 
 			if err != nil {
-				log.Debug(err)
+				log.Error(err)
 				return
 			}
 

--- a/internal/app/cf-terraforming/cmd/worker_route.go
+++ b/internal/app/cf-terraforming/cmd/worker_route.go
@@ -105,7 +105,7 @@ func workerResourceStateBuild(zone cloudflare.Zone, route cloudflare.WorkerRoute
 func workerRouteParse(zone cloudflare.Zone, route cloudflare.WorkerRoute, multiScript bool) {
 
 	tmpl := template.Must(template.New("script").Funcs(templateFuncMap).Parse(workerRouteTemplate))
-	tmpl.Execute(os.Stdout,
+	err := tmpl.Execute(os.Stdout,
 		struct {
 			Zone        cloudflare.Zone
 			Route       cloudflare.WorkerRoute
@@ -116,4 +116,7 @@ func workerRouteParse(zone cloudflare.Zone, route cloudflare.WorkerRoute, multiS
 			Route:       route,
 			MultiScript: multiScript,
 		})
+	if err != nil {
+		log.Error(err)
+	}
 }

--- a/internal/app/cf-terraforming/cmd/worker_script.go
+++ b/internal/app/cf-terraforming/cmd/worker_script.go
@@ -39,7 +39,7 @@ var workerScriptCmd = &cobra.Command{
 			workerScripts, err := api.ListWorkerScripts()
 
 			if err != nil {
-				log.Debug(err)
+				log.Error(err)
 				return
 			}
 			// Loop through every script and fetch its content for rendering into tfstate format
@@ -55,11 +55,10 @@ var workerScriptCmd = &cobra.Command{
 					if strings.Contains(downloadErr.Error(), "HTTP status 404") {
 						log.WithFields(logrus.Fields{
 							"Script ID": script.ID,
-						}).Debug("Error fetching script - does this zone have the workers entitlement?")
-
+						}).Error("Error fetching script - does this zone have the workers entitlement?")
 						continue
 					}
-					log.Debug(downloadErr)
+					log.Error(downloadErr)
 				}
 
 				if workerScriptResponse.Success == true {
@@ -87,11 +86,11 @@ var workerScriptCmd = &cobra.Command{
 					if strings.Contains(singleScriptErr.Error(), "HTTP status 404") {
 						log.WithFields(logrus.Fields{
 							"Zone ID": zone.ID,
-						}).Debug("Error fetching script - does this zone have the workers entitlement?")
+						}).Error("Error fetching script - does this zone have the workers entitlement?")
 
 						continue
 					}
-					log.Debug(singleScriptErr)
+					log.Error(singleScriptErr)
 				}
 				// It's possible for the script ID to be unset in some cases,
 				// so set a default value

--- a/internal/app/cf-terraforming/cmd/worker_script.go
+++ b/internal/app/cf-terraforming/cmd/worker_script.go
@@ -115,7 +115,7 @@ var workerScriptCmd = &cobra.Command{
 
 func workerScriptParse(scriptName string, zoneName string, script cloudflare.WorkerScript, multiScript bool) {
 	tmpl := template.Must(template.New("script").Funcs(templateFuncMap).Parse(workerScriptTemplate))
-	tmpl.Execute(os.Stdout,
+	err := tmpl.Execute(os.Stdout,
 		struct {
 			ScriptName  string
 			ZoneName    string
@@ -127,4 +127,7 @@ func workerScriptParse(scriptName string, zoneName string, script cloudflare.Wor
 			Script:      script,
 			MultiScript: multiScript,
 		})
+	if err != nil {
+		log.Error(err)
+	}
 }

--- a/internal/app/cf-terraforming/cmd/zone.go
+++ b/internal/app/cf-terraforming/cmd/zone.go
@@ -68,7 +68,7 @@ var zoneCmd = &cobra.Command{
 			zoneDetails, err := api.ZoneDetails(zone.ID)
 
 			if err != nil {
-				log.Debug(err)
+				log.Error(err)
 				return
 			}
 

--- a/internal/app/cf-terraforming/cmd/zone.go
+++ b/internal/app/cf-terraforming/cmd/zone.go
@@ -89,7 +89,7 @@ var zoneCmd = &cobra.Command{
 
 func zoneParse(zone cloudflare.Zone) {
 	tmpl := template.Must(template.New("zone").Funcs(templateFuncMap).Parse(zoneTemplate))
-	tmpl.Execute(os.Stdout,
+	err := tmpl.Execute(os.Stdout,
 		struct {
 			Zone     cloudflare.Zone
 			ZonePlan string
@@ -97,6 +97,9 @@ func zoneParse(zone cloudflare.Zone) {
 			Zone:     zone,
 			ZonePlan: idForName[zone.Plan.Name],
 		})
+	if err != nil {
+		log.Error(err)
+	}
 }
 
 func zoneResourceStateBuild(zone cloudflare.Zone) Resource {

--- a/internal/app/cf-terraforming/cmd/zone_lockdown.go
+++ b/internal/app/cf-terraforming/cmd/zone_lockdown.go
@@ -83,7 +83,7 @@ var zoneLockdownCmd = &cobra.Command{
 
 func zoneLockdownParse(zone cloudflare.Zone, lockdown cloudflare.ZoneLockdown) {
 	tmpl := template.Must(template.New("zone_lockdown").Funcs(templateFuncMap).Parse(zoneLockdownTemplate))
-	tmpl.Execute(os.Stdout,
+	err := tmpl.Execute(os.Stdout,
 		struct {
 			Zone     cloudflare.Zone
 			Lockdown cloudflare.ZoneLockdown
@@ -91,6 +91,9 @@ func zoneLockdownParse(zone cloudflare.Zone, lockdown cloudflare.ZoneLockdown) {
 			Zone:     zone,
 			Lockdown: lockdown,
 		})
+	if err != nil {
+		log.Error(err)
+	}
 }
 
 func zoneLockdownResourceStateBuild(zone cloudflare.Zone, record cloudflare.ZoneLockdown) Resource {

--- a/internal/app/cf-terraforming/cmd/zone_lockdown.go
+++ b/internal/app/cf-terraforming/cmd/zone_lockdown.go
@@ -56,7 +56,7 @@ var zoneLockdownCmd = &cobra.Command{
 				lockdowns, err := api.ListZoneLockdowns(zone.ID, page)
 
 				if err != nil {
-					log.Debug(err)
+					log.Error(err)
 					return
 				}
 

--- a/internal/app/cf-terraforming/cmd/zone_settings_override.go
+++ b/internal/app/cf-terraforming/cmd/zone_settings_override.go
@@ -85,7 +85,7 @@ var zoneSettingsOverrideCmd = &cobra.Command{
 
 func zoneSettingsOverrideParse(s []cloudflare.ZoneSetting, zone cloudflare.Zone) {
 	tmpl := template.Must(template.New("script").Funcs(templateFuncMap).Parse(zoneSettingOverrideTemplate))
-	tmpl.Execute(os.Stdout,
+	err := tmpl.Execute(os.Stdout,
 		struct {
 			Settings []cloudflare.ZoneSetting
 			Zone     cloudflare.Zone
@@ -93,4 +93,7 @@ func zoneSettingsOverrideParse(s []cloudflare.ZoneSetting, zone cloudflare.Zone)
 			Settings: s,
 			Zone:     zone,
 		})
+	if err != nil {
+		log.Error(err)
+	}
 }

--- a/internal/app/cf-terraforming/cmd/zone_settings_override.go
+++ b/internal/app/cf-terraforming/cmd/zone_settings_override.go
@@ -53,7 +53,7 @@ var zoneSettingsOverrideCmd = &cobra.Command{
 			settingsResponse, err := api.ZoneSettings(zone.ID)
 
 			if err != nil {
-				log.Debug(err)
+				log.Error(err)
 				return
 			}
 


### PR DESCRIPTION
This fixes several reported problems with the rate-limit command -  e.g. #118, #110, #51.

To make similar issues easier to spot in future, I've made _all_ templates log at error level, as well as all API-call errors.