### PR TITLE
Factorize Record Resource name generation and escape '*'

### DIFF
--- a/internal/app/cf-terraforming/cmd/record.go
+++ b/internal/app/cf-terraforming/cmd/record.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 	"text/template"
 	"time"
 
@@ -14,7 +13,7 @@ import (
 )
 
 const recordTemplate = `
-resource "cloudflare_record" "{{.Record.Type}}_{{replace .Record.Name "." "_"}}_{{.Record.ID}}" {
+resource "cloudflare_record" "{{recordResourceName .Record}}" {
     zone_id = "{{.Zone.ID}}"
 {{ if .Zone.Paused}}
     paused = "true"
@@ -143,7 +142,7 @@ var recordCmd = &cobra.Command{
 
 				if tfstate {
 					state := recordResourceStateBuild(zone, r)
-					name := r.Type + "_" + strings.ReplaceAll(r.Name, ".", "_") + "_" + r.ID
+					name := recordResourceName(r)
 					resourcesMap["cloudflare_record."+name] = state
 				} else {
 					recordParse(zone, r)
@@ -170,6 +169,10 @@ func recordParse(zone cloudflare.Zone, record cloudflare.DNSRecord) {
 	if err != nil {
 		log.Error(err)
 	}
+}
+
+func recordResourceName(record cloudflare.DNSRecord) string {
+	return normalizeResourceName(record.Type + "_" + record.Name + "_" + record.ID)
 }
 
 func recordResourceStateBuild(zone cloudflare.Zone, record cloudflare.DNSRecord) Resource {

--- a/internal/app/cf-terraforming/cmd/util.go
+++ b/internal/app/cf-terraforming/cmd/util.go
@@ -45,11 +45,18 @@ func normalizeRecordName(name, domain string) string {
 	return strings.TrimSuffix(name, "."+domain)
 }
 
+func normalizeResourceName(name string) string {
+	r := strings.NewReplacer(".", "_", "*", "star")
+
+	return r.Replace(name)
+}
+
 var templateFuncMap = template.FuncMap{
 	"replace":       replace,
 	"isMap":         isMap,
 	"quoteIfString": quoteIfString,
 	"normalizeRecordName": normalizeRecordName,
+	"recordResourceName": recordResourceName,
 }
 
 func hashMap(values map[string]string) int {


### PR DESCRIPTION
This change factorizes the generation of record resource name and allows to escape all characters in one place.

It adds `*` (replaced with string `star`) as a character that needs to be escaped.

For a `*.test.example.com` A record, resource name will be `cloudflare_record.A_star_test_example_com_58b8edf6db17f71ecd93f5093d755266`

Fixes #148