### PR TITLE
Update Zone Name to Zone ID in WAF Rule Template

### DIFF
--- a/internal/app/cf-terraforming/cmd/waf_rule.go
+++ b/internal/app/cf-terraforming/cmd/waf_rule.go
@@ -13,7 +13,7 @@ import (
 const wafRuleTemplate = `
 resource "cloudflare_waf_rule" "{{replace .Zone.Name "." "_"}}_{{.Rule.ID}}" {
     rule_id = "{{.Rule.ID}}"
-    zone = "{{.Zone.Name}}"
+    zone_id = "{{.Zone.ID}}"
     mode = "{{.Rule.Mode}}"
 }
 `


### PR DESCRIPTION
The WAF rule template is outdated and uses `zone` instead of `zone_id` in the terraform resource, this updates it.