### PR TITLE
Various fixes

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -870,6 +870,7 @@ golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -877,6 +878,7 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/internal/app/cf-terraforming/cmd/access_policy.go
+++ b/internal/app/cf-terraforming/cmd/access_policy.go
@@ -21,7 +21,7 @@ resource "cloudflare_access_policy" "access_policy_{{.Policy.ID}}" {
     decision = "{{.Policy.Decision}}"
 
 {{if .Policy.Include }}
-    include = {
+    include {
 {{range $k, $v := .Policy.Include }}
     {{if isMap $v }}
         {{- range $k, $v := $v }}

--- a/internal/app/cf-terraforming/cmd/access_policy.go
+++ b/internal/app/cf-terraforming/cmd/access_policy.go
@@ -27,6 +27,8 @@ resource "cloudflare_access_policy" "access_policy_{{.Policy.ID}}" {
         {{- range $k, $v := $v }}
 			{{ if eq $k "everyone" }}
 			{{ $k }} = "true"
+			{{ else if eq $k "certificate" }}
+			{{ $k }} = true
 			{{ else }}
             {{ $k }} =  {{if isMap $v }} [{{range $v}}"{{.}}",{{end}}]  {{else}} "{{ $v }}" {{end}}
 			{{ end }}

--- a/internal/app/cf-terraforming/cmd/load_balancer_monitor.go
+++ b/internal/app/cf-terraforming/cmd/load_balancer_monitor.go
@@ -24,7 +24,8 @@ resource "cloudflare_load_balancer_monitor" "load_balancer_monitor_{{.LBM.ID}}" 
     {{if isMap .LBM.Header}}
     header {
     {{range $k, $v := .LBM.Header}}
-        {{$k}} = {{ quoteIfString $v }}
+        header = {{$k}}
+		values = {{ quoteIfString $v }}
     {{end}}
     }
     {{end}}

--- a/internal/app/cf-terraforming/cmd/load_balancer_monitor.go
+++ b/internal/app/cf-terraforming/cmd/load_balancer_monitor.go
@@ -25,7 +25,7 @@ resource "cloudflare_load_balancer_monitor" "load_balancer_monitor_{{.LBM.ID}}" 
     header {
     {{range $k, $v := .LBM.Header}}
         header = {{$k}}
-		values = {{ quoteIfString $v }}
+        values = {{ quoteIfString $v }}
     {{end}}
     }
     {{end}}

--- a/internal/app/cf-terraforming/cmd/load_balancer_monitor.go
+++ b/internal/app/cf-terraforming/cmd/load_balancer_monitor.go
@@ -24,8 +24,8 @@ resource "cloudflare_load_balancer_monitor" "load_balancer_monitor_{{.LBM.ID}}" 
     {{if isMap .LBM.Header}}
     header {
     {{range $k, $v := .LBM.Header}}
-        header = {{$k}}
-        values = {{ quoteIfString $v }}
+        header = "{{$k}}"
+        values = [{{ range $hv := $v }}"{{ $hv }}",{{ end }}]
     {{end}}
     }
     {{end}}

--- a/internal/app/cf-terraforming/cmd/page_rule.go
+++ b/internal/app/cf-terraforming/cmd/page_rule.go
@@ -42,6 +42,8 @@ resource "cloudflare_page_rule" "page_rule_{{.Rule.ID}}" {
         }
     {{ else if isSlice .Value}}
         {{- .ID }} = [ {{ range .Value }}"{{.}}", {{ end }} ]
+    {{ else if eq .ID "always_use_https"  }}
+        {{.ID }} = true
     {{else}}
         {{.ID}} = {{ quoteIfString .Value }}
     {{end -}}

--- a/internal/app/cf-terraforming/cmd/page_rule.go
+++ b/internal/app/cf-terraforming/cmd/page_rule.go
@@ -44,6 +44,8 @@ resource "cloudflare_page_rule" "page_rule_{{.Rule.ID}}" {
         {{- .ID }} = [ {{ range .Value }}"{{.}}", {{ end }} ]
     {{ else if eq .ID "always_use_https"  }}
         {{.ID }} = true
+    {{ else if eq .ID "disable_security"  }}
+        {{.ID }} = true
     {{else}}
         {{.ID}} = {{ quoteIfString .Value }}
     {{end -}}

--- a/internal/app/cf-terraforming/cmd/worker_route.go
+++ b/internal/app/cf-terraforming/cmd/worker_route.go
@@ -15,7 +15,7 @@ const workerRouteTemplate = `
 resource "cloudflare_worker_route" "worker_route_{{.Route.ID}}" {
     zone_id = "{{.Zone.ID}}"
     pattern = "{{.Route.Pattern}}"
-    script_name = cloudflare_worker_script.{{.Route.Script}}
+    script_name = cloudflare_worker_script.{{replace .Route.Script "-" "_"}}.name
 }
 `
 

--- a/internal/app/cf-terraforming/cmd/zone_lockdown.go
+++ b/internal/app/cf-terraforming/cmd/zone_lockdown.go
@@ -22,12 +22,11 @@ resource "cloudflare_zone_lockdown" "{{replace .Zone.Name "." "_"}}_{{.Lockdown.
         "{{.}}",
 {{end}}
     ]
-    configurations = [
 {{range .Lockdown.Configurations}}
-        {
-            target = "{{.Target}}"
-            value = "{{.Value}}"
-        },
+    configurations {
+      target = "{{.Target}}"
+      value  = "{{.Value}}"
+    }
 {{end}}
     ]
 }

--- a/internal/app/cf-terraforming/cmd/zone_lockdown.go
+++ b/internal/app/cf-terraforming/cmd/zone_lockdown.go
@@ -28,7 +28,6 @@ resource "cloudflare_zone_lockdown" "{{replace .Zone.Name "." "_"}}_{{.Lockdown.
       value  = "{{.Value}}"
     }
 {{end}}
-    ]
 }
 `
 


### PR DESCRIPTION
1. LB monitor header as per [docs](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/load_balancer_monitor#header)
```
  header {
    header = "Host"
    values = ["example.com"]
  }
```

2. `cloudflare_worker_route` use right script name ref.

`script_name = cloudflare_worker_script.mtls-add-headers` => `script_name = cloudflare_worker_script.mtls_add_headers.name`

```
...
resource "cloudflare_worker_script" "mtls_add_headers" {
...
```

3. Handle `always_use_https` in page rules

Since this action does not have any value we should use its presence as fact that it is enabled.
fixes: `always_use_https = ""` => `always_use_https = true`

4. `cloudflare_access_policy`

- include is now block
```  
include {
    certificate = true
}
```
- handle `certificate = true`

5. Handle `disable_security` in page rules

Since this action does not have any value we should use its presence as fact that it is enabled.
fixes: `disable_security = ""` => `disable_security = true`

6. Fix `zone_lockdown` configurations 