### PR TITLE
generate: add support for `cloudflare_custom_hostname_fallback_origin`

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -275,6 +275,25 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 			for i := 0; i < resourceCount; i++ {
 				jsonStructData[i].(map[string]interface{})["type"] = jsonStructData[i].(map[string]interface{})["id"]
 			}
+		case "cloudflare_custom_hostname_fallback_origin":
+			var jsonPayload []cloudflare.CustomHostnameFallbackOrigin
+			apiCall, err := api.CustomHostnameFallbackOrigin(context.Background(), zoneID)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			if apiCall.Origin != "" {
+				resourceCount = 1
+				jsonPayload = append(jsonPayload, apiCall)
+			}
+
+			m, _ := json.Marshal(jsonPayload)
+			json.Unmarshal(m, &jsonStructData)
+
+			for i := 0; i < resourceCount; i++ {
+				jsonStructData[i].(map[string]interface{})["id"] = sanitiseTerraformResourceName(jsonStructData[i].(map[string]interface{})["origin"].(string))
+				jsonStructData[i].(map[string]interface{})["status"] = nil
+			}
 		case "cloudflare_filter":
 			jsonPayload, err := api.Filters(context.Background(), zoneID, cloudflare.PaginationOptions{})
 			if err != nil {

--- a/internal/app/cf-terraforming/cmd/generate_test.go
+++ b/internal/app/cf-terraforming/cmd/generate_test.go
@@ -97,6 +97,7 @@ func TestResourceGeneration(t *testing.T) {
 		"cloudflare custom pages (zone)":                    {identiferType: "zone", resourceType: "cloudflare_custom_pages", testdataFilename: "cloudflare_custom_pages_zone"},
 		"cloudflare custom pages (account)":                 {identiferType: "account", resourceType: "cloudflare_custom_pages", testdataFilename: "cloudflare_custom_pages_account"},
 		"cloudflare custom hostname":                        {identiferType: "zone", resourceType: "cloudflare_custom_hostname", testdataFilename: "cloudflare_custom_hostname"},
+		"cloudflare custom hostname fallback origin":        {identiferType: "zone", resourceType: "cloudflare_custom_hostname_fallback_origin", testdataFilename: "cloudflare_custom_hostname_fallback_origin"},
 		"cloudflare filter":                                 {identiferType: "zone", resourceType: "cloudflare_filter", testdataFilename: "cloudflare_filter"},
 		"cloudflare firewall rule":                          {identiferType: "zone", resourceType: "cloudflare_firewall_rule", testdataFilename: "cloudflare_firewall_rule"},
 		"cloudflare health check":                           {identiferType: "zone", resourceType: "cloudflare_healthcheck", testdataFilename: "cloudflare_healthcheck"},

--- a/internal/app/cf-terraforming/cmd/util.go
+++ b/internal/app/cf-terraforming/cmd/util.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
@@ -113,4 +114,11 @@ func sharedPreRun(cmd *cobra.Command, args []string) {
 			log.Fatal(err)
 		}
 	}
+}
+
+// sanitiseTerraformResourceName ensures that a Terraform resource name matches the
+// restrictions imposed by core.
+func sanitiseTerraformResourceName(s string) string {
+	re := regexp.MustCompile(`[^a-zA-Z0-9_]+`)
+	return re.ReplaceAllString(s, "_")
 }

--- a/testdata/cloudflare/cloudflare_custom_hostname_fallback_origin.yaml
+++ b/testdata/cloudflare/cloudflare_custom_hostname_fallback_origin.yaml
@@ -1,0 +1,35 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: https://api.cloudflare.com/client/v4/zones/0da42c8d2132a9ddaf714f9e7c920711/custom_hostnames/fallback_origin
+    method: GET
+  response:
+    body: |
+      {
+        "success": true,
+        "errors": [],
+        "messages": [],
+        "result": {
+          "origin": "fallback.example.com",
+          "status": "pending_deployment",
+          "created_at": "2020-08-17T19:16:43.006255Z",
+          "updated_at": "2021-04-12T00:54:48.350843Z",
+          "errors": [
+            "DNS records are not setup correctly. Origin should be a proxied A/AAAA/CNAME dns record"
+          ]
+        }
+      }
+    headers:
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept-Encoding
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/testdata/terraform/cloudflare_custom_hostname_fallback_origin.tf
+++ b/testdata/terraform/cloudflare_custom_hostname_fallback_origin.tf
@@ -1,0 +1,4 @@
+resource "cloudflare_custom_hostname_fallback_origin" "terraform_managed_resource" {
+  origin = "fallback.example.com"
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+}


### PR DESCRIPTION
Updates the generate command to support generating the
`cloudflare_custom_hostname_fallback_origin` resource