### PR TITLE
generate: remove `tfexec.LockTimeout` on init

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -56,7 +56,7 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 			log.Fatal(err)
 		}
 
-		err = tf.Init(context.Background(), tfexec.Upgrade(true), tfexec.LockTimeout("60s"))
+		err = tf.Init(context.Background(), tfexec.Upgrade(true))
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
Terraform 0.15 deprecates `-lock-timeout` and it is now failing in CI.

```
time="2021-04-14T19:24:20Z" level=fatal msg="-lock, -lock-timeout, -verify-plugins, and -get-plugins options are no longer available as of Terraform 0.15: unexpected version 0.15.0 (min: -, max: 0.15.0)"
```

We don't really need it so let's just remove it.

Closes #237
