### PR TITLE
version: provide more metadata for non-released builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CLOUDFLARE_EMAIL      ?= example@example.com
 CLOUDFLARE_API_KEY    ?= aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 CLOUDFLARE_ZONE_ID    ?= 00deadb33f000000000000000000000000000
 CLOUDFLARE_ACCOUNT_ID ?= 00deadb33f000000000000000000000000000
-VERSION               ?= dev+$$(git rev-parse --short HEAD)
+VERSION               ?= $$(git describe --tags --abbrev=0)-dev+$$(git rev-parse --short=12 HEAD)
 
 HASHICORP_CHECKPOINT_TIMEMOUT ?= 30000
 

--- a/internal/app/cf-terraforming/cmd/version.go
+++ b/internal/app/cf-terraforming/cmd/version.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"os/exec"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -16,6 +18,21 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number of cf-terraforming",
 	Run: func(cmd *cobra.Command, args []string) {
+		if versionString == "dev" {
+			gitDescribe := exec.Command("git", "describe", "--tags", "--abbrev=0")
+			gitDescribeStdout, err := gitDescribe.Output()
+			if err != nil {
+				log.Error("failed to exec to `git`")
+			}
+
+			gitSha := exec.Command("git", "rev-parse", "--short=12", "HEAD")
+			gitShaStdout, err := gitSha.Output()
+			if err != nil {
+				log.Error("failed to exec to `git`")
+			}
+			versionString = strings.TrimSpace(string(gitDescribeStdout)) + "-" + versionString + "+" + strings.TrimSpace(string(gitShaStdout))
+		}
+
 		fmt.Printf("cf-terraforming %s\n", versionString)
 	},
 }


### PR DESCRIPTION
Provides a better `version` output by including the nearest git tag,
"dev" and the head commit. This will ensure that all cases of version
are better annotated.

- Total development build using `go run`

```
$ go run cmd/cf-terraforming/main.go version
cf-terraforming v0.1.1-dev+9330aec123ca
```

- Local `make build` with no version defined

```
$ make build && ./cf-terraforming version
cf-terraforming v0.1.1-dev+9330aec123ca
```

- Local `make build` with version defined (aka an actual release)

```
$ VERSION="v0.0.0" make build && ./cf-terraforming version
cf-terraforming v0.0.0
```

Fixes #243
