### PR TITLE
generate: handle non-string values for IDs

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -519,7 +519,15 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 			if os.Getenv("USE_STATIC_RESOURCE_IDS") == "true" {
 				resourceID = "terraform_managed_resource"
 			} else {
-				resourceID = fmt.Sprintf("terraform_managed_resource_%s", structData["id"].(string))
+				id := ""
+				switch structData["id"].(type) {
+				case float64:
+					id = fmt.Sprintf("%f", structData["id"].(float64))
+				default:
+					id = structData["id"].(string)
+				}
+
+				resourceID = fmt.Sprintf("terraform_managed_resource_%s", id)
 			}
 
 			output += fmt.Sprintf(`resource "%s" "%s" {`+"\n", resourceType, resourceID)


### PR DESCRIPTION
Updates the name generation to handle scenarios where the ID is not a
string value. This is incredibly uncommon (logpush is the only service
exposing a non-string hash value) however this will fix the crash while
I chase up the internal team whether this is intentionally different.

Fixes #248
