### PR TITLE
generate: remove cloudflare_zone status from output

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -542,6 +542,7 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 				jsonStructData[i].(map[string]interface{})["plan"] = jsonStructData[i].(map[string]interface{})["plan"].(map[string]interface{})["legacy_id"].(string)
 				jsonStructData[i].(map[string]interface{})["meta"] = nil
 				jsonStructData[i].(map[string]interface{})["name_servers"] = nil
+				jsonStructData[i].(map[string]interface{})["status"] = nil
 			}
 		case "cloudflare_zone_lockdown":
 			jsonPayload, err := api.ListZoneLockdowns(context.Background(), zoneID, 1)


### PR DESCRIPTION
The `cloudflare_zone` status field is returned by the API but isn't
really usable by Terraform. Just remove it instead if outputting it.

Closes #262
