### PR TITLE
generate: map `default_pool_ids` and `fallback_pool_id` load balancer values

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -355,6 +355,11 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 			resourceCount = len(jsonPayload)
 			m, _ := json.Marshal(jsonPayload)
 			json.Unmarshal(m, &jsonStructData)
+
+			for i := 0; i < resourceCount; i++ {
+				jsonStructData[i].(map[string]interface{})["default_pool_ids"] = jsonStructData[i].(map[string]interface{})["default_pools"]
+				jsonStructData[i].(map[string]interface{})["fallback_pool_id"] = jsonStructData[i].(map[string]interface{})["fallback_pool"]
+			}
 		case "cloudflare_load_balancer_pool":
 			jsonPayload, err := api.ListLoadBalancerPools(context.Background())
 			if err != nil {

--- a/testdata/terraform/cloudflare_load_balancer.tf
+++ b/testdata/terraform/cloudflare_load_balancer.tf
@@ -1,6 +1,8 @@
 resource "cloudflare_load_balancer" "terraform_managed_resource" {
+  default_pool_ids = [ "17b5962d775c646f3f9725cbc7a53df4", "9290f38c5d07c2e2f4df57b1f61d4196", "00920f38ce07c2e2f4df50b1f61d4194" ]
   description = "Load Balancer for www.example.com"
   enabled = true
+  fallback_pool_id = "17b5962d775c646f3f9725cbc7a53df4"
   name = "www.example.com"
   proxied = true
   session_affinity = "cookie"


### PR DESCRIPTION
The API response for the load balancer endpoint has the values named a
little differently so we need to remap them for generation.

- `default_pools` => `default_pool_ids`
- `fallback_pool` => `fallback_pool_id`

Closes #264