### PR TITLE
cloudflare_argo: add initial support

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Last updated May 7, 2021
 | [cloudflare_access_service_token](https://www.terraform.io/docs/providers/cloudflare/r/access_service_token.html) | ✔️ |
 | [cloudflare_account_member](https://www.terraform.io/docs/providers/cloudflare/r/account_member.html) | ✔️ |
 | [cloudflare_api_token](https://www.terraform.io/docs/providers/cloudflare/r/api_token.html) | ✖️ |
-| [cloudflare_argo](https://www.terraform.io/docs/providers/cloudflare/r/argo.html) | ✖️ |
+| [cloudflare_argo](https://www.terraform.io/docs/providers/cloudflare/r/argo.html) | ✔️ |
 | [cloudflare_argo_tunnel](https://www.terraform.io/docs/providers/cloudflare/r/argo_tunnel.html) | ✔️ |
 | [cloudflare_authenticated_origin_pulls](https://www.terraform.io/docs/providers/cloudflare/r/authenticated_origin_pulls.html) | ✖️ |
 | [cloudflare_authenticated_origin_pulls_certificate](https://www.terraform.io/docs/providers/cloudflare/r/authenticated_origin_pulls_certificate.html) | ✖️ |

--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -212,6 +212,30 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 				}
 				jsonStructData[i].(map[string]interface{})["role_ids"] = roleIDs
 			}
+		case "cloudflare_argo":
+			jsonPayload := []cloudflare.ArgoFeatureSetting{}
+
+			argoSmartRouting, err := api.ArgoSmartRouting(context.Background(), zoneID)
+			if err != nil {
+				log.Fatal(err)
+			}
+			jsonPayload = append(jsonPayload, argoSmartRouting)
+
+			argoTieredCaching, err := api.ArgoTieredCaching(context.Background(), zoneID)
+			if err != nil {
+				log.Fatal(err)
+			}
+			jsonPayload = append(jsonPayload, argoTieredCaching)
+
+			resourceCount = 1
+
+			m, _ := json.Marshal(jsonPayload)
+			json.Unmarshal(m, &jsonStructData)
+
+			for _, b := range jsonStructData {
+				key := b.(map[string]interface{})["id"].(string)
+				jsonStructData[0].(map[string]interface{})[key] = jsonStructData[0].(map[string]interface{})["value"]
+			}
 		case "cloudflare_argo_tunnel":
 			jsonPayload, err := api.ArgoTunnels(context.Background(), accountID)
 			if err != nil {

--- a/internal/app/cf-terraforming/cmd/generate_test.go
+++ b/internal/app/cf-terraforming/cmd/generate_test.go
@@ -115,6 +115,10 @@ func TestResourceGeneration(t *testing.T) {
 		"cloudflare zone lockdown":                          {identiferType: "zone", resourceType: "cloudflare_zone_lockdown", testdataFilename: "cloudflare_zone_lockdown"},
 		"cloudflare page rule":                              {identiferType: "zone", resourceType: "cloudflare_page_rule", testdataFilename: "cloudflare_page_rule"},
 
+		// We can't yet test `cloudflare_argo` as it makes multiple API requests and
+		// the Go library we are using doesn't play nicely with nested cassettes.
+		// "cloudflare argo": {identiferType: "zone", resourceType: "cloudflare_argo", testdataFilename: "cloudflare_argo"},
+
 		// "cloudflare access group (account)": {identiferType: "account", resourceType: "cloudflare_access_group", testdataFilename: "cloudflare_access_group_account"},
 		// "cloudflare access group (zone)":    {identiferType: "zone", resourceType: "cloudflare_access_group", testdataFilename: "cloudflare_access_group_zone"},
 		// "cloudflare custom certificates":    {identiferType: "zone", resourceType: "cloudflare_custom_certificates", testdataFilename: "cloudflare_custom_certificates"},

--- a/internal/app/cf-terraforming/cmd/import.go
+++ b/internal/app/cf-terraforming/cmd/import.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"context"
+	"crypto/md5"
 	"encoding/json"
 	"strings"
+	"time"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/spf13/cobra"
@@ -16,6 +18,7 @@ import (
 var resourceImportStringFormats = map[string]string{
 	"cloudflare_access_rule":           ":identifer_type/:identifer_value/:id",
 	"cloudflare_account_member":        ":account_id/:id",
+	"cloudflare_argo":                  ":zone_id/argo",
 	"cloudflare_argo_tunnel":           ":account_id/:id",
 	"cloudflare_byo_ip_prefix":         ":id",
 	"cloudflare_certificate_pack":      ":zone_id/:id",
@@ -75,6 +78,13 @@ func runImport() func(cmd *cobra.Command, args []string) {
 			if err != nil {
 				log.Fatal(err)
 			}
+			m, _ := json.Marshal(jsonPayload)
+			json.Unmarshal(m, &jsonStructData)
+		case "cloudflare_argo":
+			jsonPayload := []cloudflare.ArgoFeatureSetting{{
+				ID: fmt.Sprintf("%x", md5.Sum([]byte(time.Now().String()))),
+			}}
+
 			m, _ := json.Marshal(jsonPayload)
 			json.Unmarshal(m, &jsonStructData)
 		case "cloudflare_argo_tunnel":

--- a/testdata/cloudflare/cloudflare_argo_smart_routing.yaml
+++ b/testdata/cloudflare/cloudflare_argo_smart_routing.yaml
@@ -1,0 +1,32 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: https://api.cloudflare.com/client/v4/zones/0da42c8d2132a9ddaf714f9e7c920711/argo/smart_routing
+    method: GET
+  response:
+    body: |
+      {
+        "result": {
+          "id": "smart_routing",
+          "value": "off",
+          "modified_on": "2021-08-29T22:07:38.044691Z",
+          "editable": true
+        },
+        "success": true,
+        "errors": [],
+        "messages": []
+      }
+    headers:
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept-Encoding
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/testdata/cloudflare/cloudflare_argo_tiered_caching.yaml
+++ b/testdata/cloudflare/cloudflare_argo_tiered_caching.yaml
@@ -1,0 +1,32 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: https://api.cloudflare.com/client/v4/zones/0da42c8d2132a9ddaf714f9e7c920711/argo/tiered_caching
+    method: GET
+  response:
+    body: |
+      {
+        "result": {
+          "id": "tiered_caching",
+          "value": "off",
+          "modified_on": "2021-08-29T22:07:38.044691Z",
+          "editable": true
+        },
+        "success": true,
+        "errors": [],
+        "messages": []
+      }
+    headers:
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept-Encoding
+    status: 200 OK
+    code: 200
+    duration: ""


### PR DESCRIPTION
Introduces support for `cloudflare_argo` to be exported and imported. This
resource is a little different from most (but definitely not unique) as it
makes multiple API requests in order to populate the resource. This makes it
really hard to test in the current setup despite being a very simple resource.