### PR TITLE
import/cloudflare_zone: use correct replacement value

### DIFF
--- a/internal/app/cf-terraforming/cmd/import.go
+++ b/internal/app/cf-terraforming/cmd/import.go
@@ -36,7 +36,7 @@ var resourceImportStringFormats = map[string]string{
 	"cloudflare_waf_override":          ":zone_id/:id",
 	"cloudflare_worker_route":          ":zone_id/:id",
 	"cloudflare_workers_kv_namespace":  ":id",
-	"cloudflare_zone":                  ":zone_id",
+	"cloudflare_zone":                  ":id",
 	"cloudflare_zone_lockdown":         ":zone_id/:id",
 }
 


### PR DESCRIPTION
In the `Import` context, `zone_id` doesn't exist as we're targeting an account
so the correct replacement should be `:id` (the resource ID).

Closes #282