### PR TITLE
generate: don't export universal `cloudflare_certificate_pack`

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -275,6 +275,14 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 				log.Fatal(err)
 			}
 
+			var customerManagedCertificates []cloudflare.CertificatePack
+			for _, r := range jsonPayload {
+				if r.Type != "universal" {
+					customerManagedCertificates = append(customerManagedCertificates, r)
+				}
+			}
+			jsonPayload = customerManagedCertificates
+
 			resourceCount = len(jsonPayload)
 			m, _ := json.Marshal(jsonPayload)
 			json.Unmarshal(m, &jsonStructData)


### PR DESCRIPTION
Universal SSL certificates cannot be managed by customers so there isn't
any reason why we should export these.

Closes #284