### PR TITLE
Handle case for nested map interfaces

### DIFF
--- a/testdata/terraform/cloudflare_rate_limit.tf
+++ b/testdata/terraform/cloudflare_rate_limit.tf
@@ -22,11 +22,13 @@ resource "cloudflare_rate_limit" "terraform_managed_resource" {
       url_pattern = "example.com"
     }
     response {
-      headers {
-        name  = "My_origin_field"
-        op    = "eq"
-        value = "block_request"
-      }
+      headers = [
+       {
+           name  = "My_origin_field"
+           op    = "eq"
+           value = "block_request"
+       }
+      ]
       origin_traffic = false
       statuses       = [401, 403]
     }


### PR DESCRIPTION
We were unconditionally rendering interfaces, even if it was a map of interfaces. This lead to us just rendering the only first value in the map as an interface. 
This fix handles the case for map of interfaces.