### PR TITLE
Check for nil on ratelimit bypass field

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -500,10 +500,12 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 				jsonStructData[i].(map[string]interface{})["match"].(map[string]interface{})["request"].(map[string]interface{})["url_pattern"] = jsonStructData[i].(map[string]interface{})["match"].(map[string]interface{})["request"].(map[string]interface{})["url"]
 
 				// Remap bypass to bypass_url_patterns
-				for _, item := range jsonStructData[i].(map[string]interface{})["bypass"].([]interface{}) {
-					bypassItems = append(bypassItems, item.(map[string]interface{})["value"].(string))
+				if jsonStructData[i].(map[string]interface{})["bypass"] != nil {
+					for _, item := range jsonStructData[i].(map[string]interface{})["bypass"].([]interface{}) {
+						bypassItems = append(bypassItems, item.(map[string]interface{})["value"].(string))
+					}
+					jsonStructData[i].(map[string]interface{})["bypass_url_patterns"] = bypassItems
 				}
-				jsonStructData[i].(map[string]interface{})["bypass_url_patterns"] = bypassItems
 
 				// Remap match.response.status to match.response.statuses
 				jsonStructData[i].(map[string]interface{})["match"].(map[string]interface{})["response"].(map[string]interface{})["statuses"] = jsonStructData[i].(map[string]interface{})["match"].(map[string]interface{})["response"].(map[string]interface{})["status"]


### PR DESCRIPTION
Before
```
panic: interface conversion: interface {} is nil, not []interface {}

goroutine 1 [running]:
github.com/cloudflare/cf-terraforming/internal/app/cf-terraforming/cmd.generateResources.func1(0x228c4c0, {0x19f2838, 0x4, 0x4})
	/Users/sachin/cf-repos/cf-terraforming/internal/app/cf-terraforming/cmd/generate.go:504 +0x7756
github.com/spf13/cobra.(*Command).execute(0x228c4c0, {0xc00004ca40, 0x4, 0x4})
	/Users/sachin/cf-repos/cf-terraforming/vendor/github.com/spf13/cobra/command.go:860 +0x5f8
github.com/spf13/cobra.(*Command).ExecuteC(0x228c9c0)
	/Users/sachin/cf-repos/cf-terraforming/vendor/github.com/spf13/cobra/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/sachin/cf-repos/cf-terraforming/vendor/github.com/spf13/cobra/command.go:902
github.com/cloudflare/cf-terraforming/internal/app/cf-terraforming/cmd.Execute()
	/Users/sachin/cf-repos/cf-terraforming/internal/app/cf-terraforming/cmd/root.go:30 +0x25
main.main()
	/Users/sachin/cf-repos/cf-terraforming/cmd/cf-terraforming/main.go:8 +0x17
exit status 2
```

After
```
resource "cloudflare_rate_limit" "terraform_managed_resource_44424eb54fd0449bb6153fa03dce1579" {
  description = "Test"
  period      = 10
  threshold   = 1
  zone_id     = "89fc2e5fb3093ad129eca62641452986"
  action {
    mode    = "ban"
    timeout = 60
  }
  match {
    request {
      methods     = ["_ALL_"]
      schemes     = ["_ALL_"]
      url_pattern = "*.example.com"
    }
  }
}
```