### PR TITLE
generate: prevent `--account` and `--zone` being used together

### DIFF
--- a/internal/app/cf-terraforming/cmd/util.go
+++ b/internal/app/cf-terraforming/cmd/util.go
@@ -66,6 +66,11 @@ func testDataFile(filename string) string {
 
 func sharedPreRun(cmd *cobra.Command, args []string) {
 	accountID = viper.GetString("account")
+	zoneID = viper.GetString("zone")
+
+	if accountID != "" && zoneID != "" {
+		log.Fatal("--account and --zone are mutually exclusive and cannot be used together")
+	}
 
 	if apiToken = viper.GetString("token"); apiToken == "" {
 		if apiEmail = viper.GetString("email"); apiEmail == "" {


### PR DESCRIPTION
These flags are mutually exclusive and are used to determine which level
(zone or account) resources should be exported. The previous behaviour
would discard zone in the event of a collision.