### PR TITLE
add cloudflare_waiting_room generate and import

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Last updated Nov 2, 2021
 | [cloudflare_waf_override](https://www.terraform.io/docs/providers/cloudflare/r/waf_override) | ✅ |
 | [cloudflare_waf_package](https://www.terraform.io/docs/providers/cloudflare/r/waf_package) | ❌ |
 | [cloudflare_waf_rule](https://www.terraform.io/docs/providers/cloudflare/r/waf_rule) | ❌ |
+| [cloudflare_waiting_room](https://www.terraform.io/docs/providers/cloudflare/r/waiting_room) | ✅ |
 | [cloudflare_worker_cron_trigger](https://www.terraform.io/docs/providers/cloudflare/r/worker_cron_trigger) | ❌ |
 | [cloudflare_worker_route](https://www.terraform.io/docs/providers/cloudflare/r/worker_route) | ✅ |
 | [cloudflare_worker_script](https://www.terraform.io/docs/providers/cloudflare/r/worker_script) | ❌ |

--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -617,6 +617,14 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 			resourceCount = len(jsonPayload)
 			m, _ := json.Marshal(jsonPayload)
 			json.Unmarshal(m, &jsonStructData)
+		case "cloudflare_waiting_room":
+			jsonPayload, err := api.ListWaitingRooms(context.Background(), zoneID)
+			if err != nil {
+				log.Fatal(err)
+			}
+			resourceCount = len(jsonPayload)
+			m, _ := json.Marshal(jsonPayload)
+			json.Unmarshal(m, &jsonStructData)
 		case "cloudflare_workers_kv_namespace":
 			jsonPayload, err := api.ListWorkersKVNamespaces(context.Background())
 			if err != nil {

--- a/internal/app/cf-terraforming/cmd/generate_test.go
+++ b/internal/app/cf-terraforming/cmd/generate_test.go
@@ -115,6 +115,7 @@ func TestResourceGeneration(t *testing.T) {
 		"cloudflare ruleset":                                {identiferType: "zone", resourceType: "cloudflare_ruleset", testdataFilename: "cloudflare_ruleset_zone"},
 		"cloudflare spectrum application":                   {identiferType: "zone", resourceType: "cloudflare_spectrum_application", testdataFilename: "cloudflare_spectrum_application"},
 		"cloudflare WAF override":                           {identiferType: "zone", resourceType: "cloudflare_waf_override", testdataFilename: "cloudflare_waf_override"},
+		"cloudflare waiting room":                           {identiferType: "zone", resourceType: "cloudflare_waiting_room", testdataFilename: "cloudflare_waiting_room"},
 		"cloudflare worker route":                           {identiferType: "zone", resourceType: "cloudflare_worker_route", testdataFilename: "cloudflare_worker_route"},
 		"cloudflare workers kv namespace":                   {identiferType: "account", resourceType: "cloudflare_workers_kv_namespace", testdataFilename: "cloudflare_workers_kv_namespace"},
 		"cloudflare zone lockdown":                          {identiferType: "zone", resourceType: "cloudflare_zone_lockdown", testdataFilename: "cloudflare_zone_lockdown"},

--- a/internal/app/cf-terraforming/cmd/import.go
+++ b/internal/app/cf-terraforming/cmd/import.go
@@ -34,6 +34,7 @@ var resourceImportStringFormats = map[string]string{
 	"cloudflare_record":                ":zone_id/:id",
 	"cloudflare_spectrum_application":  ":zone_id/:id",
 	"cloudflare_waf_override":          ":zone_id/:id",
+	"cloudflare_waiting_room":          ":zone_id/:id",
 	"cloudflare_worker_route":          ":zone_id/:id",
 	"cloudflare_workers_kv_namespace":  ":id",
 	"cloudflare_zone":                  ":id",
@@ -219,6 +220,13 @@ func runImport() func(cmd *cobra.Command, args []string) {
 			json.Unmarshal(m, &jsonStructData)
 		case "cloudflare_waf_package":
 			jsonPayload, err := api.ListWAFPackages(context.Background(), zoneID)
+			if err != nil {
+				log.Fatal(err)
+			}
+			m, _ := json.Marshal(jsonPayload)
+			json.Unmarshal(m, &jsonStructData)
+		case "cloudflare_waiting_room":
+			jsonPayload, err := api.ListWaitingRooms(context.Background(), zoneID)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/testdata/cloudflare/cloudflare_waiting_room.yaml
+++ b/testdata/cloudflare/cloudflare_waiting_room.yaml
@@ -1,50 +1,50 @@
 ---
 version: 1
 interactions:
-  - request:
-      body: ""
-      form: {}
-      headers:
-        Content-Type:
-          - application/json
-      url: https://api.cloudflare.com/client/v4/zones/0da42c8d2132a9ddaf714f9e7c920711/waiting_rooms
-      method: GET
-    response:
-      body: |
-        {
-          "success": true,
-          "errors": [],
-          "messages": [],
-          "result": [
-            {
-              "id": "699d98642c564d2e855e9661899b7252",
-              "created_on": "2014-01-01T05:20:00.12345Z",
-              "modified_on": "2014-01-01T05:20:00.12345Z",
-              "name": "production_webinar",
-              "description": "Production - DO NOT MODIFY",
-              "suspended": false,
-              "host": "shop.example.com",
-              "path": "/shop/checkout",
-              "queue_all": true,
-              "new_users_per_minute": 1000,
-              "total_active_users": 1000,
-              "session_duration": 10,
-              "disable_session_renewal": false,
-              "json_response_enabled": false,
-              "queueing_method": "fifo",
-              "cookie_attributes": {
-                "samesite": "auto",
-                "secure": "auto"
-              },
-              "custom_page_html": "{{#waitTimeKnown}} {{waitTime}} mins {{/waitTimeKnown}} {{^waitTimeKnown}} Queue all enabled {{/waitTimeKnown}}"
-            }
-          ]
-        }
-      headers:
-        Content-Type:
-          - application/json
-        Vary:
-          - Accept-Encoding
-      status: 200 OK
-      code: 200
-      duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: https://api.cloudflare.com/client/v4/zones/0da42c8d2132a9ddaf714f9e7c920711/waiting_rooms
+    method: GET
+  response:
+    body: |
+      {
+        "success": true,
+        "errors": [],
+        "messages": [],
+        "result": [
+          {
+            "id": "699d98642c564d2e855e9661899b7252",
+            "created_on": "2014-01-01T05:20:00.12345Z",
+            "modified_on": "2014-01-01T05:20:00.12345Z",
+            "name": "production_webinar",
+            "description": "Production - DO NOT MODIFY",
+            "suspended": false,
+            "host": "shop.example.com",
+            "path": "/shop/checkout",
+            "queue_all": true,
+            "new_users_per_minute": 1000,
+            "total_active_users": 1000,
+            "session_duration": 10,
+            "disable_session_renewal": false,
+            "json_response_enabled": false,
+            "queueing_method": "fifo",
+            "cookie_attributes": {
+              "samesite": "auto",
+              "secure": "auto"
+            },
+            "custom_page_html": "{{#waitTimeKnown}} {{waitTime}} mins {{/waitTimeKnown}} {{^waitTimeKnown}} Queue all enabled {{/waitTimeKnown}}"
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept-Encoding
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/testdata/cloudflare/cloudflare_waiting_room.yaml
+++ b/testdata/cloudflare/cloudflare_waiting_room.yaml
@@ -1,0 +1,50 @@
+---
+version: 1
+interactions:
+  - request:
+      body: ""
+      form: {}
+      headers:
+        Content-Type:
+          - application/json
+      url: https://api.cloudflare.com/client/v4/zones/0da42c8d2132a9ddaf714f9e7c920711/waiting_rooms
+      method: GET
+    response:
+      body: |
+        {
+          "success": true,
+          "errors": [],
+          "messages": [],
+          "result": [
+            {
+              "id": "699d98642c564d2e855e9661899b7252",
+              "created_on": "2014-01-01T05:20:00.12345Z",
+              "modified_on": "2014-01-01T05:20:00.12345Z",
+              "name": "production_webinar",
+              "description": "Production - DO NOT MODIFY",
+              "suspended": false,
+              "host": "shop.example.com",
+              "path": "/shop/checkout",
+              "queue_all": true,
+              "new_users_per_minute": 1000,
+              "total_active_users": 1000,
+              "session_duration": 10,
+              "disable_session_renewal": false,
+              "json_response_enabled": false,
+              "queueing_method": "fifo",
+              "cookie_attributes": {
+                "samesite": "auto",
+                "secure": "auto"
+              },
+              "custom_page_html": "{{#waitTimeKnown}} {{waitTime}} mins {{/waitTimeKnown}} {{^waitTimeKnown}} Queue all enabled {{/waitTimeKnown}}"
+            }
+          ]
+        }
+      headers:
+        Content-Type:
+          - application/json
+        Vary:
+          - Accept-Encoding
+      status: 200 OK
+      code: 200
+      duration: ""

--- a/testdata/terraform/cloudflare_waiting_room.tf
+++ b/testdata/terraform/cloudflare_waiting_room.tf
@@ -1,0 +1,15 @@
+resource "cloudflare_waiting_room" "terraform_managed_resource" {
+  zone_id                 = "0da42c8d2132a9ddaf714f9e7c920711"
+  name                    = "production_webinar"
+  description             = "Production - DO NOT MODIFY"
+  suspended               = false
+  host                    = "shop.example.com"
+  path                    = "/shop/checkout"
+  queue_all               = true
+  new_users_per_minute    = 1000
+  total_active_users      = 1000
+  session_duration        = 10
+  disable_session_renewal = false
+  json_response_enabled   = false
+  custom_page_html        = "{{#waitTimeKnown}} {{waitTime}} mins {{/waitTimeKnown}} {{^waitTimeKnown}} Queue all enabled {{/waitTimeKnown}}"
+}

--- a/testdata/terraform/cloudflare_waiting_room.tf
+++ b/testdata/terraform/cloudflare_waiting_room.tf
@@ -1,15 +1,15 @@
 resource "cloudflare_waiting_room" "terraform_managed_resource" {
-  zone_id                 = "0da42c8d2132a9ddaf714f9e7c920711"
-  name                    = "production_webinar"
+  custom_page_html        = "{{#waitTimeKnown}} {{waitTime}} mins {{/waitTimeKnown}} {{^waitTimeKnown}} Queue all enabled {{/waitTimeKnown}}"
   description             = "Production - DO NOT MODIFY"
-  suspended               = false
+  disable_session_renewal = false
   host                    = "shop.example.com"
+  json_response_enabled   = false
+  name                    = "production_webinar"
+  new_users_per_minute    = 1000
   path                    = "/shop/checkout"
   queue_all               = true
-  new_users_per_minute    = 1000
-  total_active_users      = 1000
   session_duration        = 10
-  disable_session_renewal = false
-  json_response_enabled   = false
-  custom_page_html        = "{{#waitTimeKnown}} {{waitTime}} mins {{/waitTimeKnown}} {{^waitTimeKnown}} Queue all enabled {{/waitTimeKnown}}"
+  suspended               = false
+  total_active_users      = 1000
+  zone_id                 = "0da42c8d2132a9ddaf714f9e7c920711"
 }


### PR DESCRIPTION
Add `generate` and `import` support for Cloudflare waiting rooms.
The example data is taken from the [waiting rooms api docs](https://api.cloudflare.com/#waiting-room-list-waiting-rooms).