### PR TITLE
import: don't generate universal cloudflare_certificate_pack

### DIFF
--- a/internal/app/cf-terraforming/cmd/import.go
+++ b/internal/app/cf-terraforming/cmd/import.go
@@ -107,6 +107,15 @@ func runImport() func(cmd *cobra.Command, args []string) {
 			if err != nil {
 				log.Fatal(err)
 			}
+			
+			var customerManagedCertificates []cloudflare.CertificatePack
+			for _, r := range jsonPayload {
+				if r.Type != "universal" {
+					customerManagedCertificates = append(customerManagedCertificates, r)
+				}
+			}
+			jsonPayload = customerManagedCertificates
+			
 			m, _ := json.Marshal(jsonPayload)
 			json.Unmarshal(m, &jsonStructData)
 		case "cloudflare_custom_pages":


### PR DESCRIPTION
Fixing import after generation was modified here: https://github.com/cloudflare/cf-terraforming/pull/306
Generating import commands for universal cloudflare_certificate_pack is not usable if config generation is skipped for them.