### PR TITLE
cmd: allow `hostname` to be configurable from the CLI

### DIFF
--- a/internal/app/cf-terraforming/cmd/root.go
+++ b/internal/app/cf-terraforming/cmd/root.go
@@ -9,7 +9,7 @@ import (
 )
 
 var log = logrus.New()
-var cfgFile, zoneID, apiEmail, apiKey, apiToken, accountID, terraformInstallPath string
+var cfgFile, zoneID, hostname, apiEmail, apiKey, apiToken, accountID, terraformInstallPath string
 var verbose bool
 var api *cloudflare.API
 var terraformImportCmdPrefix = "terraform import"
@@ -69,6 +69,10 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&apiToken, "token", "t", "", "API Token")
 	viper.BindPFlag("token", rootCmd.PersistentFlags().Lookup("token"))
 	viper.BindEnv("token", "CLOUDFLARE_API_TOKEN")
+
+	rootCmd.PersistentFlags().StringVarP(&hostname, "hostname", "", "", "Hostname to use to query the API")
+	viper.BindPFlag("hostname", rootCmd.PersistentFlags().Lookup("hostname"))
+	viper.BindEnv("hostname", "CLOUDFLARE_API_HOSTNAME")
 
 	// Debug logging mode
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Specify verbose output (same as setting log level to debug)")

--- a/internal/app/cf-terraforming/cmd/util.go
+++ b/internal/app/cf-terraforming/cmd/util.go
@@ -67,6 +67,7 @@ func testDataFile(filename string) string {
 func sharedPreRun(cmd *cobra.Command, args []string) {
 	accountID = viper.GetString("account")
 	zoneID = viper.GetString("zone")
+	hostname = viper.GetString("hostname")
 
 	if accountID != "" && zoneID != "" {
 		log.Fatal("--account and --zone are mutually exclusive and cannot be used together")
@@ -105,9 +106,8 @@ func sharedPreRun(cmd *cobra.Command, args []string) {
 		options = append(options, cloudflare.UsingAccount(accountID))
 	}
 
-	var apiHost string
-	if apiHost = os.Getenv("CLOUDFLARE_API_HOSTNAME"); apiHost != "" {
-		options = append(options, cloudflare.BaseURL("https://"+apiHost+"/client/v4"))
+	if hostname != "" {
+		options = append(options, cloudflare.BaseURL("https://"+hostname+"/client/v4"))
 	}
 
 	var err error


### PR DESCRIPTION
Updates the flags to support passing in the API hostname to use via the
`--hostname` flag.

Closes #343