### PR TITLE
cmd: enable `Debug` on the API client for verbose mode

### DIFF
--- a/internal/app/cf-terraforming/cmd/util.go
+++ b/internal/app/cf-terraforming/cmd/util.go
@@ -110,6 +110,10 @@ func sharedPreRun(cmd *cobra.Command, args []string) {
 		options = append(options, cloudflare.BaseURL("https://"+apiHost+"/client/v4"))
 	}
 
+	if verbose {
+		options = append(options, cloudflare.Debug(true))
+	}
+
 	var err error
 
 	// Don't initialise a client in CI as this messes with VCR and the ability to


### PR DESCRIPTION
In cloudflare/cloudflare-go#841 I introduced a simple debug for those
who need to see the HTTP traffic but don't want to add their own logger
or client implementation. This introduces that for cf-terraforming to
help with diagnosing issues.

example

```
DEBU[0000] initializing cloudflare-go                    account_id= email=jacob.bednarz@gmail.com zone_id=0da42c8d2132a9ddaf714f9e7c920711
DEBU[0007] initialising Terraform in /Users/jacob/src/scratch
DEBU[0009] reading Terraform schema for Cloudflare provider
DEBU[0009] beginning to read and build cloudflare_record resources
cloudflare-go [DEBUG] REQUEST Method:GET URI:https://api.cloudflare.com/client/v4/zones/0da42c8d2132a9ddaf714f9e7c920711/dns_records?page=1 Headers:http.Header(nil) Body:<nil>
cloudflare-go [DEBUG] RESPONSE URI:https://api.cloudflare.com/client/v4 StatusCode:200 Body:"{\"result\":[{\"id\":\"b8c38d3a3d290871013c2b8a7b0b0775\",\"zone_id\":\"0da42c8d2132a9ddaf714f9e7c920711\",\"zone_name\":\"cf-terraform.example.com\",\"name\":\"cf-terraform.example.com\",\"type\":\"CNAME\",\"content\":\"example.net\",\"proxiable\":true,\"proxied\":true,\"ttl\":1,\"locked\":false,\"meta\":{\"auto_added\":false,\"managed_by_apps\":false,\"managed_by_argo_tunnel\":false,\"source\":\"primary\"},\"created_on\":\"2022-03-08T03:32:26.518583Z\",\"modified_on\":\"2022-04-06T19:57:17.492135Z\"}],\"success\":true,\"errors\":[],\"messages\":[],\"result_info\":{\"page\":1,\"per_page\":100,\"count\":1,\"total_count\":1,\"total_pages\":1}}" RayID:6f87393c0f3ca811-SYD
DEBU[0010] got unknown attribute configuration: key allow_overwrite, value <nil>, value type <nil>
DEBU[0010] got unknown attribute configuration: key hostname, value <nil>, value type <nil>
DEBU[0010] got unknown attribute configuration: key metadata, value <nil>, value type <nil>
DEBU[0010] got unknown attribute configuration: key priority, value <nil>, value type <nil>
DEBU[0010] got unknown attribute configuration: key proxiable, value <nil>, value type <nil>
DEBU[0010] unexpected attribute struct type <nil> for block data
DEBU[0010] nested mode "single" for timeouts not recognised
resource "cloudflare_record" "terraform_managed_resource_b8c38d3a3d290871013c2b8a7b0b0775" {
  name    = "cf-terraform.example.com"
  proxied = true
  ttl     = 1
  type    = "CNAME"
  value   = "example.net"
  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
}
```