### PR TITLE
Allow both zone and account because of workers

### DIFF
--- a/internal/app/cf-terraforming/cmd/util.go
+++ b/internal/app/cf-terraforming/cmd/util.go
@@ -71,7 +71,7 @@ func sharedPreRun(cmd *cobra.Command, args []string) {
 	hostname = viper.GetString("hostname")
 
 	if accountID != "" && zoneID != "" {
-		log.Fatal("--account and --zone are mutually exclusive and cannot be used together")
+		log.Debug("--account and --zone are mutually exclusive, support for both is deprecated")
 	}
 
 	if apiToken = viper.GetString("token"); apiToken == "" {


### PR DESCRIPTION
Unfortunately, cloudflare-go uses both zone and account ID to make API calls for workers routes and filters.
We end up generating bad config without account IDs.
The filter API is currently deprecated https://api.cloudflare.com/#worker-filters-deprecated--list-filters
And the real fix before we can make zones and accounts exclusive in cf-tf is to deprecate the filters endpoint in cloudflare-go
I'll get to working on that in cloudflare-go. In the mean time to keep things unblocked I'm rolling this change back.
Sorry Jacob, I know you wanted this. I did put in a debug statement for deprecation, so hopefully that helps.