### PR TITLE
generate: add `origins.header` mapping for load balancer

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -417,6 +417,15 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 			resourceCount = len(jsonPayload)
 			m, _ := json.Marshal(jsonPayload)
 			json.Unmarshal(m, &jsonStructData)
+
+			for i := 0; i < resourceCount; i++ {
+				for originCounter, _ := range jsonStructData[i].(map[string]interface{})["origins"].([]interface{}) {
+					if jsonStructData[i].(map[string]interface{})["origins"].([]interface{})[originCounter].(map[string]interface{})["header"] != nil {
+						jsonStructData[i].(map[string]interface{})["origins"].([]interface{})[originCounter].(map[string]interface{})["header"].(map[string]interface{})["header"] = "Host"
+						jsonStructData[i].(map[string]interface{})["origins"].([]interface{})[originCounter].(map[string]interface{})["header"].(map[string]interface{})["values"] = jsonStructData[i].(map[string]interface{})["origins"].([]interface{})[originCounter].(map[string]interface{})["header"].(map[string]interface{})["Host"]
+					}
+				}
+			}
 		case "cloudflare_load_balancer_monitor":
 			jsonPayload, err := api.ListLoadBalancerMonitors(context.Background())
 			if err != nil {

--- a/internal/app/cf-terraforming/cmd/generate_test.go
+++ b/internal/app/cf-terraforming/cmd/generate_test.go
@@ -100,6 +100,7 @@ func TestResourceGeneration(t *testing.T) {
 		"cloudflare health check":                           {identiferType: "zone", resourceType: "cloudflare_healthcheck", testdataFilename: "cloudflare_healthcheck"},
 		"cloudflare load balancer monitor":                  {identiferType: "account", resourceType: "cloudflare_load_balancer_monitor", testdataFilename: "cloudflare_load_balancer_monitor"},
 		"cloudflare load balancer":                          {identiferType: "zone", resourceType: "cloudflare_load_balancer", testdataFilename: "cloudflare_load_balancer"},
+		"cloudflare load balancer pool":                     {identiferType: "account", resourceType: "cloudflare_load_balancer_pool", testdataFilename: "cloudflare_load_balancer_pool"},
 		"cloudflare logpush jobs":                           {identiferType: "zone", resourceType: "cloudflare_logpush_job", testdataFilename: "cloudflare_logpush_job"},
 		"cloudflare origin CA certificate":                  {identiferType: "zone", resourceType: "cloudflare_origin_ca_certificate", testdataFilename: "cloudflare_origin_ca_certificate"},
 		"cloudflare page rule":                              {identiferType: "zone", resourceType: "cloudflare_page_rule", testdataFilename: "cloudflare_page_rule"},

--- a/testdata/terraform/cloudflare_load_balancer_pool.tf
+++ b/testdata/terraform/cloudflare_load_balancer_pool.tf
@@ -6,4 +6,14 @@ resource "cloudflare_load_balancer_pool" "terraform_managed_resource" {
   monitor            = "f1aba936b94213e5b8dca0c0dbf1f9cc"
   name               = "primary-dc-1"
   notification_email = "someone@example.com,sometwo@example.com"
+  origins {
+    address = "0.0.0.0"
+    enabled = true
+    name    = "app-server-1"
+    weight  = 1
+    header {
+      header = "Host"
+      values = ["example.com"]
+    }
+  }
 }


### PR DESCRIPTION
The API response differs from the schema so we need to remap it to
output correctly.

Closes #266