### PR TITLE
should null exclude in exclude block

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -514,7 +514,7 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 						jsonStructData[i].(map[string]interface{})["actions"].(map[string]interface{})["cache_key_fields"].(map[string]interface{})["query_string"].(map[string]interface{})["ignore"] = false
 					}
 					if s, sok := c["query_string"].(map[string]interface{})["exclude"].(string); sok && s == "*" {
-						jsonStructData[i].(map[string]interface{})["actions"].(map[string]interface{})["cache_key_fields"].(map[string]interface{})["query_string"].(map[string]interface{})["include"] = []interface{}{}
+						jsonStructData[i].(map[string]interface{})["actions"].(map[string]interface{})["cache_key_fields"].(map[string]interface{})["query_string"].(map[string]interface{})["exclude"] = []interface{}{}
 						jsonStructData[i].(map[string]interface{})["actions"].(map[string]interface{})["cache_key_fields"].(map[string]interface{})["query_string"].(map[string]interface{})["ignore"] = true
 					}
 				}


### PR DESCRIPTION
we found this issue while working on Http Applications. We're not nullifying `exclude = '*'` in page rules.