### PR TITLE
Add missing "enabled to status" transformations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+.idea/

--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -688,19 +688,41 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 			}
 
 			for i := 0; i < resourceCount; i++ {
-				if jsonStructData[i].(map[string]interface{})["rules"] != nil {
-					for ruleCounter := range jsonStructData[i].(map[string]interface{})["rules"].([]interface{}) {
-						if jsonStructData[i].(map[string]interface{})["rules"].([]interface{})[ruleCounter].(map[string]interface{})["action_parameters"] != nil {
-							if jsonStructData[i].(map[string]interface{})["rules"].([]interface{})[ruleCounter].(map[string]interface{})["action_parameters"].(map[string]interface{})["overrides"] != nil {
-								if jsonStructData[i].(map[string]interface{})["rules"].([]interface{})[ruleCounter].(map[string]interface{})["action_parameters"].(map[string]interface{})["overrides"].(map[string]interface{})["enabled"] == true {
-									jsonStructData[i].(map[string]interface{})["rules"].([]interface{})[ruleCounter].(map[string]interface{})["action_parameters"].(map[string]interface{})["overrides"].(map[string]interface{})["status"] = "enabled"
+				rules := jsonStructData[i].(map[string]interface{})["rules"]
+				if rules != nil {
+					for ruleCounter := range rules.([]interface{}) {
+						actionParams := rules.([]interface{})[ruleCounter].(map[string]interface{})["action_parameters"]
+						if actionParams != nil {
+							overrides := actionParams.(map[string]interface{})["overrides"]
+							if overrides != nil {
+								if overrides.(map[string]interface{})["enabled"] == true {
+									overrides.(map[string]interface{})["status"] = "enabled"
 								}
 
-								if jsonStructData[i].(map[string]interface{})["rules"].([]interface{})[ruleCounter].(map[string]interface{})["action_parameters"].(map[string]interface{})["overrides"].(map[string]interface{})["enabled"] == false {
-									jsonStructData[i].(map[string]interface{})["rules"].([]interface{})[ruleCounter].(map[string]interface{})["action_parameters"].(map[string]interface{})["overrides"].(map[string]interface{})["status"] = "disabled"
+								if overrides.(map[string]interface{})["enabled"] == false {
+									overrides.(map[string]interface{})["status"] = "disabled"
 								}
 
-								jsonStructData[i].(map[string]interface{})["rules"].([]interface{})[ruleCounter].(map[string]interface{})["action_parameters"].(map[string]interface{})["overrides"].(map[string]interface{})["enabled"] = nil
+								overrides.(map[string]interface{})["enabled"] = nil
+
+								for key, _ := range overrides.(map[string]interface{}) {
+									overrideRules, ok := overrides.(map[string]interface{})[key].([]interface{})
+									if !ok || overrideRules == nil {
+										continue
+									}
+
+									for j := range overrideRules {
+										if overrideRules[j].(map[string]interface{})["enabled"] == true {
+											overrideRules[j].(map[string]interface{})["status"] = "enabled"
+										}
+
+										if overrideRules[j].(map[string]interface{})["enabled"] == false {
+											overrideRules[j].(map[string]interface{})["status"] = "disabled"
+										}
+
+										overrideRules[j].(map[string]interface{})["enabled"] = nil
+									}
+								}
 							}
 						}
 					}

--- a/testdata/cloudflare/cloudflare_ruleset_override_remapping_disabled.yaml
+++ b/testdata/cloudflare/cloudflare_ruleset_override_remapping_disabled.yaml
@@ -112,7 +112,19 @@ interactions:
                 "version": "latest",
                 "overrides": {
                   "action": "log",
-                  "enabled": false
+                  "enabled": false,
+                  "categories": [
+                    {
+                      "category": "paranoia-level-2",
+                      "enabled": false
+                    }
+                  ],
+                  "rules": [
+                    {
+                      "id": "6179ae15870a4bb7b2d480d4843b323c",
+                      "enabled": false
+                    }
+                  ]
                 }
               },
               "expression": "(http.cookie eq \"jb_testing=true\")",

--- a/testdata/cloudflare/cloudflare_ruleset_override_remapping_enabled.yaml
+++ b/testdata/cloudflare/cloudflare_ruleset_override_remapping_enabled.yaml
@@ -112,7 +112,19 @@ interactions:
                 "version": "latest",
                 "overrides": {
                   "action": "log",
-                  "enabled": true
+                  "enabled": true,
+                  "categories": [
+                    {
+                      "category": "paranoia-level-2",
+                      "enabled": true
+                    }
+                  ],
+                  "rules": [
+                    {
+                      "id": "6179ae15870a4bb7b2d480d4843b323c",
+                      "enabled": true
+                    }
+                  ]
                 }
               },
               "expression": "(http.cookie eq \"jb_testing=true\")",

--- a/testdata/terraform/cloudflare_ruleset_override_remapping_disabled/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_override_remapping_disabled/test.tf
@@ -10,6 +10,14 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     expression  = "(http.cookie eq \"jb_testing=true\")"
     action_parameters {
       overrides {
+        categories {
+          category = "paranoia-level-2"
+          status   = "disabled"
+        }
+        rules {
+          id     = "6179ae15870a4bb7b2d480d4843b323c"
+          status = "disabled"
+        }
         action = "log"
         status = "disabled"
       }

--- a/testdata/terraform/cloudflare_ruleset_override_remapping_enabled/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_override_remapping_enabled/test.tf
@@ -10,6 +10,14 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     expression  = "(http.cookie eq \"jb_testing=true\")"
     action_parameters {
       overrides {
+        categories {
+          category = "paranoia-level-2"
+          status   = "enabled"
+        }
+        rules {
+          id     = "6179ae15870a4bb7b2d480d4843b323c"
+          status = "enabled"
+        }
         action = "log"
         status = "enabled"
       }

--- a/testdata/terraform/cloudflare_ruleset_zone/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone/test.tf
@@ -10,8 +10,8 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     action_parameters {
       overrides {
         rules {
-          enabled = true
-          id      = "78723a9e0c7c4c6dbec5684cb766231d"
+          id     = "78723a9e0c7c4c6dbec5684cb766231d"
+          status = "enabled"
         }
       }
       id      = "70339d97bdb34195bbf054b1ebe81f76"

--- a/testdata/terraform/cloudflare_ruleset_zone_http_request_sanitize/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_http_request_sanitize/test.tf
@@ -10,8 +10,8 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     action_parameters {
       overrides {
         rules {
-          enabled = true
-          id      = "78723a9e0c7c4c6dbec5684cb766231d"
+          id     = "78723a9e0c7c4c6dbec5684cb766231d"
+          status = "enabled"
         }
       }
       id      = "70339d97bdb34195bbf054b1ebe81f76"

--- a/testdata/terraform/cloudflare_waiting_room/test.tf
+++ b/testdata/terraform/cloudflare_waiting_room/test.tf
@@ -8,6 +8,7 @@ resource "cloudflare_waiting_room" "terraform_managed_resource" {
   new_users_per_minute    = 1000
   path                    = "/shop/checkout"
   queue_all               = true
+  queueing_method         = "fifo"
   session_duration        = 10
   suspended               = false
   total_active_users      = 1000


### PR DESCRIPTION
We were experiencing clone failures in HTTP Applications. After investigations, I found that the generated terraform `cloudflare_rulesets` resource is incorrect.

The `enabled` field in Category and Rules based overrides for `cloudflare_rulesets` was deprecated. Terraform provider is looking for a `status` status field instead. This PR aims to complete the missing `enabled->status` transformations.

Terraform Provider already looking for the new `status` fields:
- https://github.com/tamas-jozsa/terraform-provider-cloudflare/blob/master/internal/provider/resource_cloudflare_ruleset.go#L671-L675
- https://github.com/tamas-jozsa/terraform-provider-cloudflare/blob/master/internal/provider/resource_cloudflare_ruleset.go#L692-L696