### PR TITLE
transform log custom action parameters

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -687,6 +687,9 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 				}
 			}
 
+			// log custom fields specfic transformation fields
+			logCustomFieldsTransform := []string{"cookie_fields", "request_fields", "response_fields"}
+
 			for i := 0; i < resourceCount; i++ {
 				rules := jsonStructData[i].(map[string]interface{})["rules"]
 				if rules != nil {
@@ -722,6 +725,19 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 
 										overrideRules[j].(map[string]interface{})["enabled"] = nil
 									}
+								}
+							}
+							// check for log custom fields that need to be transformed
+							for _, logCustomFields := range logCustomFieldsTransform {
+								// check if the field exists and make sure it has at least one element
+								if actionParams.(map[string]interface{})[logCustomFields] != nil && len(actionParams.(map[string]interface{})[logCustomFields].([]interface{})) > 0 {
+									// Create a new list to store the data in.
+									var newLogCustomFields []interface{}
+									// iterate over each of the keys and add them to a generic list
+									for logCustomFieldsCounter := range actionParams.(map[string]interface{})[logCustomFields].([]interface{}) {
+										newLogCustomFields = append(newLogCustomFields, actionParams.(map[string]interface{})[logCustomFields].([]interface{})[logCustomFieldsCounter].(map[string]interface{})["name"])
+									}
+									actionParams.(map[string]interface{})[logCustomFields] = newLogCustomFields
 								}
 							}
 						}

--- a/internal/app/cf-terraforming/cmd/generate_test.go
+++ b/internal/app/cf-terraforming/cmd/generate_test.go
@@ -118,6 +118,7 @@ func TestResourceGeneration(t *testing.T) {
 		"cloudflare ruleset (ddos_l7)":                       {identiferType: "zone", resourceType: "cloudflare_ruleset", testdataFilename: "cloudflare_ruleset_zone_ddos_l7"},
 		"cloudflare ruleset (http_request_firewall_managed)": {identiferType: "zone", resourceType: "cloudflare_ruleset", testdataFilename: "cloudflare_ruleset_zone_http_request_firewall_managed"},
 		"cloudflare ruleset (http_request_late_transform)":   {identiferType: "zone", resourceType: "cloudflare_ruleset", testdataFilename: "cloudflare_ruleset_zone_http_request_late_transform"},
+		"cloudflare ruleset (http_log_custom_fields)":        {identiferType: "zone", resourceType: "cloudflare_ruleset", testdataFilename: "cloudflare_ruleset_zone_http_log_custom_fields"},
 		"cloudflare ruleset (override remapping = enabled)":  {identiferType: "zone", resourceType: "cloudflare_ruleset", testdataFilename: "cloudflare_ruleset_override_remapping_enabled"},
 		"cloudflare ruleset (override remapping = disabled)": {identiferType: "zone", resourceType: "cloudflare_ruleset", testdataFilename: "cloudflare_ruleset_override_remapping_disabled"},
 		"cloudflare spectrum application":                    {identiferType: "zone", resourceType: "cloudflare_spectrum_application", testdataFilename: "cloudflare_spectrum_application"},

--- a/testdata/cloudflare/cloudflare_ruleset_zone_http_log_custom_fields.yaml
+++ b/testdata/cloudflare/cloudflare_ruleset_zone_http_log_custom_fields.yaml
@@ -1,0 +1,107 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: https://api.cloudflare.com/client/v4/zones/0da42c8d2132a9ddaf714f9e7c920711/rulesets
+    method: GET
+  response:
+    body: |
+      {
+        "result": [
+           {
+            "id": "4b9724cc601c443c9dfa506d8b566dc2",
+            "name": "zone",
+            "description": "",
+            "kind": "zone",
+            "version": "1",
+            "last_updated": "2021-08-30T02:38:50.39057Z",
+            "phase": "http_log_custom_fields"
+          }
+        ],
+        "success": true,
+        "errors": [],
+        "messages": []
+      }
+    headers:
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept-Encoding
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: https://api.cloudflare.com/client/v4/zones/0da42c8d2132a9ddaf714f9e7c920711/rulesets/4b9724cc601c443c9dfa506d8b566dc2
+    method: GET
+  response:
+    body: |
+      {
+        "result": {
+          "id": "4b9724cc601c443c9dfa506d8b566dc2",
+          "name": "zone",
+          "description": "",
+          "kind": "zone",
+          "version": "1",
+          "rules": [
+            {
+              "id": "17a0d1e23a3444ccbd5e58fc7793649a",
+              "version": "1",
+              "action": "log_custom_field",
+              "expression": "true",
+              "description": "zone",
+              "last_updated": "2022-07-22T12:34:45.479429Z",
+              "ref": "17a0d1e23a3444ccbd5e58fc7793649a",
+              "enabled": true,
+              "action_parameters": {
+                "cookie_fields": [
+                  {
+                    "name": "cookie"
+                  },
+                  {
+                    "name": "fields"
+                  }
+                ],
+                "request_fields": [
+                  {
+                    "name": "request"
+                  },
+                  {
+                    "name": "fields"
+                  }
+                ],
+                "response_fields": [
+                  {
+                    "name": "response"
+                  },
+                  {
+                    "name": "fields"
+                  }
+                ]
+              }
+            }
+          ],
+          "last_updated": "2021-08-30T02:38:50.39057Z",
+          "phase": "http_log_custom_fields"
+        },
+        "success": true,
+        "errors": [],
+        "messages": []
+      }
+    headers:
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept-Encoding
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/testdata/terraform/cloudflare_ruleset_zone_http_log_custom_fields/provider.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_http_log_custom_fields/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
+  }
+}

--- a/testdata/terraform/cloudflare_ruleset_zone_http_log_custom_fields/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_http_log_custom_fields/test.tf
@@ -1,0 +1,17 @@
+resource "cloudflare_ruleset" "terraform_managed_resource" {
+  kind    = "zone"
+  name    = "zone"
+  phase   = "http_log_custom_fields"
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  rules {
+    action      = "log_custom_field"
+    description = "zone"
+    enabled     = true
+    expression  = "true"
+    action_parameters {
+      cookie_fields   = ["cookie", "fields"]
+      request_fields  = ["request", "fields"]
+      response_fields = ["response", "fields"]
+    }
+  }
+}


### PR DESCRIPTION
log custom fields action parameters are not being transformed correctly to match the schema.
Before:
```
resource "cloudflare_ruleset" {
  kind    = "zone"
  name    = "default"
  phase   = "http_log_custom_fields"
  zone_id = ""
  rules {
    action      = "log_custom_field"
    description = "Set Logpush custom fields for HTTP requests"
    enabled     = true
    expression  = "true"
    action_parameters {
      cookie_fields = [
        {
          name = "asdf"
        },
        {
          name = "zxcv"
        }
      ]
    }
  }
}
```
After:
```
resource "cloudflare_ruleset" {
  kind    = "zone"
  name    = "default"
  phase   = "http_log_custom_fields"
  zone_id = ""
  rules {
    action      = "log_custom_field"
    description = "Set Logpush custom fields for HTTP requests"
    enabled     = true
    expression  = "true"
    action_parameters {
      cookie_fields = ["asdf", "zxcv"]
    }
  }
}
```

I purposefully did this specific to log custom fields. If more action_parameters start returning a list of values i think this can be transitioned to handle that. The current assumption we're making is that each of these elements will have a "name" key. 