### PR TITLE
add cloudflare_managed_headers suppport

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -195,6 +195,7 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 				resourceCount = len(jsonPayload.Result)
 				m, _ := json.Marshal(jsonPayload.Result)
 				json.Unmarshal(m, &jsonStructData)
+
 			} else {
 				jsonPayload, err := api.ListZoneAccessRules(context.Background(), zoneID, cloudflare.AccessRule{}, 1)
 				if err != nil {
@@ -470,7 +471,23 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 					jsonStructData[i].(map[string]interface{})["filter"] = nil
 				}
 			}
+		case "cloudflare_managed_headers":
+			// only grab the enabled headers
+			jsonPayload, err := api.ListZoneManagedHeaders(context.Background(), cloudflare.ResourceIdentifier(zoneID), cloudflare.ListManagedHeadersParams{Status: "enabled"})
+			if err != nil {
+				log.Fatal(err)
+			}
 
+			var managedHeaders []cloudflare.ManagedHeaders
+			managedHeaders = append(managedHeaders, jsonPayload)
+
+			resourceCount = len(managedHeaders)
+			m, _ := json.Marshal(managedHeaders)
+			json.Unmarshal(m, &jsonStructData)
+
+			for i := 0; i < resourceCount; i++ {
+				jsonStructData[i].(map[string]interface{})["id"] = zoneID
+			}
 		case "cloudflare_origin_ca_certificate":
 			jsonPayload, err := api.OriginCertificates(context.Background(), cloudflare.OriginCACertificateListOptions{ZoneID: zoneID})
 			if err != nil {

--- a/internal/app/cf-terraforming/cmd/generate_test.go
+++ b/internal/app/cf-terraforming/cmd/generate_test.go
@@ -103,6 +103,7 @@ func TestResourceGeneration(t *testing.T) {
 		"cloudflare load balancer pool":                      {identiferType: "account", resourceType: "cloudflare_load_balancer_pool", testdataFilename: "cloudflare_load_balancer_pool"},
 		"cloudflare logpush jobs":                            {identiferType: "zone", resourceType: "cloudflare_logpush_job", testdataFilename: "cloudflare_logpush_job"},
 		"cloudflare logpush jobs with filter":                {identiferType: "zone", resourceType: "cloudflare_logpush_job", testdataFilename: "cloudflare_logpush_job_with_filter"},
+		"cloudflare managed headers":                         {identiferType: "zone", resourceType: "cloudflare_managed_headers", testdataFilename: "cloudflare_managed_headers"},
 		"cloudflare origin CA certificate":                   {identiferType: "zone", resourceType: "cloudflare_origin_ca_certificate", testdataFilename: "cloudflare_origin_ca_certificate"},
 		"cloudflare page rule":                               {identiferType: "zone", resourceType: "cloudflare_page_rule", testdataFilename: "cloudflare_page_rule"},
 		"cloudflare rate limit":                              {identiferType: "zone", resourceType: "cloudflare_rate_limit", testdataFilename: "cloudflare_rate_limit"},

--- a/testdata/cloudflare/cloudflare_managed_headers.yaml
+++ b/testdata/cloudflare/cloudflare_managed_headers.yaml
@@ -1,0 +1,42 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: https://api.cloudflare.com/client/v4/zones/0da42c8d2132a9ddaf714f9e7c920711/managed_headers?status=enabled
+    method: GET
+  response:
+    body: |
+      {
+        "result": {
+          "managed_request_headers": [
+            {
+              "id": "add_visitor_location_headers",
+              "enabled": true,
+              "has_conflict": false
+            }
+          ],
+          "managed_response_headers": [
+            {
+              "id": "remove_x-powered-by_header",
+              "enabled": true,
+              "has_conflict": false
+            }
+          ]
+        },
+        "success": true,
+        "errors": [],
+        "messages": []
+      }
+    headers:
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept-Encoding
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/testdata/terraform/cloudflare_managed_headers/provider.tf
+++ b/testdata/terraform/cloudflare_managed_headers/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
+  }
+}

--- a/testdata/terraform/cloudflare_managed_headers/test.tf
+++ b/testdata/terraform/cloudflare_managed_headers/test.tf
@@ -1,0 +1,11 @@
+resource "cloudflare_managed_headers" "terraform_managed_resource" {
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  managed_request_headers {
+    enabled = true
+    id      = "add_visitor_location_headers"
+  }
+  managed_response_headers {
+    enabled = true
+    id      = "remove_x-powered-by_header"
+  }
+}


### PR DESCRIPTION
This PR adds support for the `zone/:id/managed_headers` endpoint. One weird thing about the `ListZoneManagedHeaders` is that it seems to be one of the only `List` functions that doesn't return a list. So i opted to convert the response into a list to make the transformations work. 