### PR TITLE
transform logging.enabled to logging.status

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -781,10 +781,12 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 										if rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"].(map[string]interface{})["enabled"] == true &&
 											rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"].(map[string]interface{})["status"] == nil {
 											rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"].(map[string]interface{})["status"] = "enabled"
+											delete(rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"].(map[string]interface{}), "enabled")
 										}
 										if rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"].(map[string]interface{})["enabled"] == false &&
 											rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"].(map[string]interface{})["status"] == nil {
 											rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"].(map[string]interface{})["status"] = "disabled"
+											delete(rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"].(map[string]interface{}), "enabled")
 										}
 									}
 								}

--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -769,6 +769,25 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 										}
 									}
 								}
+								// do we have a logging parameter in our rule?
+								if rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"] != nil {
+									// make sure it has data
+									if rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"].(map[string]interface{})["enabled"] != nil {
+										/*
+											enabled = true -> status = 'enabled'
+											enabled = flase -> status = 'disabled'
+											Also lets only add 'status' if it doesn't already exist
+										*/
+										if rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"].(map[string]interface{})["enabled"] == true &&
+											rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"].(map[string]interface{})["status"] == nil {
+											rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"].(map[string]interface{})["status"] = "enabled"
+										}
+										if rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"].(map[string]interface{})["enabled"] == false &&
+											rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"].(map[string]interface{})["status"] == nil {
+											rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"].(map[string]interface{})["status"] = "disabled"
+										}
+									}
+								}
 							}
 						}
 					}

--- a/internal/app/cf-terraforming/cmd/util.go
+++ b/internal/app/cf-terraforming/cmd/util.go
@@ -243,7 +243,7 @@ func nestBlocks(schemaBlock *tfjson.SchemaBlock, structData map[string]interface
 			// which case we can directly add them to the config.
 			case map[string]interface{}:
 				if attrStruct != nil {
-					nestedBlockOutput += writeNestedBlock(sortedInnerAttributes, schemaBlock.NestedBlocks[block].Block, attrStruct, parentID)
+					nestedBlockOutput += writeNestedBlock(sortedInnerAttributes, schemaBlock.NestedBlocks[block].Block, attrStruct)
 				}
 
 				if nestedBlockOutput != "" || schemaBlock.NestedBlocks[block].MinItems > 0 {
@@ -259,7 +259,7 @@ func nestBlocks(schemaBlock *tfjson.SchemaBlock, structData map[string]interface
 					repeatedBlockOutput := ""
 
 					if attrStruct != nil {
-						repeatedBlockOutput = writeNestedBlock(sortedInnerAttributes, schemaBlock.NestedBlocks[block].Block, v, parentID)
+						repeatedBlockOutput = writeNestedBlock(sortedInnerAttributes, schemaBlock.NestedBlocks[block].Block, v)
 					}
 
 					// Write the block if we had data for it, or if it is a required block.
@@ -281,7 +281,7 @@ func nestBlocks(schemaBlock *tfjson.SchemaBlock, structData map[string]interface
 				for _, v := range attrStruct {
 					repeatedBlockOutput := ""
 					if attrStruct != nil {
-						repeatedBlockOutput = writeNestedBlock(sortedInnerAttributes, schemaBlock.NestedBlocks[block].Block, v.(map[string]interface{}), parentID)
+						repeatedBlockOutput = writeNestedBlock(sortedInnerAttributes, schemaBlock.NestedBlocks[block].Block, v.(map[string]interface{}))
 					}
 
 					// Write the block if we had data for it, or if it is a required block.
@@ -331,7 +331,7 @@ func nestBlocks(schemaBlock *tfjson.SchemaBlock, structData map[string]interface
 	return output
 }
 
-func writeNestedBlock(attributes []string, schemaBlock *tfjson.SchemaBlock, attrStruct map[string]interface{}, parentID string) string {
+func writeNestedBlock(attributes []string, schemaBlock *tfjson.SchemaBlock, attrStruct map[string]interface{}) string {
 	nestedBlockOutput := ""
 
 	for _, attrName := range attributes {

--- a/testdata/cloudflare/cloudflare_ruleset_zone_http_request_firewall_custom.yaml
+++ b/testdata/cloudflare/cloudflare_ruleset_zone_http_request_firewall_custom.yaml
@@ -86,7 +86,7 @@ interactions:
                 "ref": "8751856eb4cf4dfdaca9a3b5e9376b1c",
                 "enabled": true,
                 "logging": {
-                  "enabled": true
+                  "enabled": false
                 },
                 "action_parameters": {
                     "ruleset": "current"

--- a/testdata/terraform/cloudflare_ruleset_zone_http_request_firewall_custom/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_http_request_firewall_custom/test.tf
@@ -15,6 +15,7 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     }
     logging {
       enabled = true
+      status  = "enabled"
     }
   }
   rules {
@@ -26,7 +27,8 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
       ruleset = "current"
     }
     logging {
-      enabled = true
+      enabled = false
+      status  = "disabled"
     }
   }
 }

--- a/testdata/terraform/cloudflare_ruleset_zone_http_request_firewall_custom/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_http_request_firewall_custom/test.tf
@@ -14,8 +14,7 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
       }
     }
     logging {
-      enabled = true
-      status  = "enabled"
+      status = "enabled"
     }
   }
   rules {
@@ -27,8 +26,7 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
       ruleset = "current"
     }
     logging {
-      enabled = false
-      status  = "disabled"
+      status = "disabled"
     }
   }
 }


### PR DESCRIPTION
the terraform provider only looks for `logging.status` and thus if `logging.enabled` is the only thing that exists, we encounter a rulesets error when attempting to run terraform apply. This PR will look at the `enabled` field and translate it to the corresponding `status` field. 

Schema: https://github.com/cloudflare/terraform-provider-cloudflare/blob/master/internal/provider/schema_cloudflare_ruleset.go#L964-L970

resource_cloudflare_ruleset: https://github.com/cloudflare/terraform-provider-cloudflare/blob/master/internal/provider/resource_cloudflare_ruleset.go#L1284-L1296