### PR TITLE
user-agent-blocking-rules: add cf-tf support for new resource

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -275,6 +275,30 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 				}
 				jsonStructData[i].(map[string]interface{})["secret"] = secret
 			}
+		case "cloudflare_user_agent_blocking_rule":
+			page := 1
+			var jsonPayload []cloudflare.UserAgentRule
+			for {
+				res, err := api.ListUserAgentRules(context.Background(), zoneID, page)
+				if err != nil {
+					log.Fatal(err)
+				}
+
+				jsonPayload = append(jsonPayload, res.Result...)
+				res.ResultInfo = res.ResultInfo.Next()
+
+				if res.ResultInfo.Done() {
+					break
+				}
+				page = page + 1
+			}
+
+			resourceCount = len(jsonPayload)
+			m, _ := json.Marshal(jsonPayload)
+			err := json.Unmarshal(m, &jsonStructData)
+			if err != nil {
+				log.Fatal(err)
+			}
 		case "cloudflare_byo_ip_prefix":
 			jsonPayload, err := api.ListPrefixes(context.Background(), accountID)
 			if err != nil {

--- a/internal/app/cf-terraforming/cmd/generate_test.go
+++ b/internal/app/cf-terraforming/cmd/generate_test.go
@@ -124,6 +124,7 @@ func TestResourceGeneration(t *testing.T) {
 		"cloudflare ruleset (override remapping = enabled)":  {identiferType: "zone", resourceType: "cloudflare_ruleset", testdataFilename: "cloudflare_ruleset_override_remapping_enabled"},
 		"cloudflare ruleset (override remapping = disabled)": {identiferType: "zone", resourceType: "cloudflare_ruleset", testdataFilename: "cloudflare_ruleset_override_remapping_disabled"},
 		"cloudflare spectrum application":                    {identiferType: "zone", resourceType: "cloudflare_spectrum_application", testdataFilename: "cloudflare_spectrum_application"},
+		"cloudflare user agent blocking rule":                {identiferType: "zone", resourceType: "cloudflare_user_agent_blocking_rule", testdataFilename: "cloudflare_user_agent_blocking_rule"},
 		"cloudflare WAF override":                            {identiferType: "zone", resourceType: "cloudflare_waf_override", testdataFilename: "cloudflare_waf_override"},
 		"cloudflare waiting room":                            {identiferType: "zone", resourceType: "cloudflare_waiting_room", testdataFilename: "cloudflare_waiting_room"},
 		"cloudflare worker route":                            {identiferType: "zone", resourceType: "cloudflare_worker_route", testdataFilename: "cloudflare_worker_route"},

--- a/testdata/cloudflare/cloudflare_user_agent_blocking_rule.yaml
+++ b/testdata/cloudflare/cloudflare_user_agent_blocking_rule.yaml
@@ -1,0 +1,45 @@
+---
+version: 1
+interactions:
+  - request:
+      body: ""
+      form: {}
+      headers:
+        Content-Type:
+          - application/json
+      url: https://api.cloudflare.com/client/v4/zones/0da42c8d2132a9ddaf714f9e7c920711/firewall/ua_rules?page=1&per_page=100
+      method: GET
+    response:
+      body: |
+        {
+          "result":[
+            {
+              "id":"23a37dba8a9b410f9338bf2efb5925c3",
+              "paused":false,
+              "description":"My description 1",
+              "mode":"js_challenge",
+              "configuration":{
+                "target":"ua",
+                "value":"Chrome"
+              }
+            }
+          ],
+          "success":true,
+          "errors":[],
+          "messages":[],
+          "result_info":{
+            "page":1,
+            "per_page":25,
+            "count":1,
+            "total_count":1,
+            "total_pages":1
+          }
+        }
+      headers:
+        Content-Type:
+          - application/json
+        Vary:
+          - Accept-Encoding
+      status: 200 OK
+      code: 200
+      duration: ""

--- a/testdata/terraform/cloudflare_user_agent_blocking_rule/provider.tf
+++ b/testdata/terraform/cloudflare_user_agent_blocking_rule/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
+  }
+}

--- a/testdata/terraform/cloudflare_user_agent_blocking_rule/test.tf
+++ b/testdata/terraform/cloudflare_user_agent_blocking_rule/test.tf
@@ -1,0 +1,10 @@
+resource "cloudflare_user_agent_blocking_rule" "terraform_managed_resource" {
+  description = "My description 1"
+  mode        = "js_challenge"
+  paused      = false
+  zone_id     = "0da42c8d2132a9ddaf714f9e7c920711"
+  configuration {
+    target = "ua"
+    value  = "Chrome"
+  }
+}


### PR DESCRIPTION
Add cf-tf support for User Agent Blocking Rules resource.

Public API: https://api.cloudflare.com/#user-agent-blocking-rules-properties 

This PR depends on the following Terraform integration: https://github.com/cloudflare/terraform-provider-cloudflare/pull/1894 