### PR TITLE
wrap alphanumeric strings in quotes. update tests

### DIFF
--- a/internal/app/cf-terraforming/cmd/util.go
+++ b/internal/app/cf-terraforming/cmd/util.go
@@ -19,6 +19,8 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+var hasNumber = regexp.MustCompile("[0-9]+").MatchString
+
 func contains(slice []string, item string) bool {
 	set := make(map[string]struct{}, len(slice))
 	for _, s := range slice {
@@ -369,9 +371,8 @@ func writeAttrLine(key string, value interface{}, usedInBlock bool) string {
 		sort.Strings(sortedKeys)
 
 		s := ""
-		// check if our key has an integer in the string. If it does we need to wrap it with quotes.
-		hasNumber := regexp.MustCompile("[0-9]+").MatchString
 		for _, v := range sortedKeys {
+			// check if our key has an integer in the string. If it does we need to wrap it with quotes.
 			if hasNumber(v) {
 				s += writeAttrLine(fmt.Sprintf("\"%s\"", v), values[v], false)
 			} else {

--- a/internal/app/cf-terraforming/cmd/util.go
+++ b/internal/app/cf-terraforming/cmd/util.go
@@ -369,8 +369,14 @@ func writeAttrLine(key string, value interface{}, usedInBlock bool) string {
 		sort.Strings(sortedKeys)
 
 		s := ""
+		// check if our key has an integer in the string. If it does we need to wrap it with quotes.
+		hasNumber := regexp.MustCompile("[0-9]+").MatchString
 		for _, v := range sortedKeys {
-			s += writeAttrLine(v, values[v], false)
+			if hasNumber(v) {
+				s += writeAttrLine(fmt.Sprintf("\"%s\"", v), values[v], false)
+			} else {
+				s += writeAttrLine(v, values[v], false)
+			}
 		}
 
 		if usedInBlock {
@@ -388,13 +394,14 @@ func writeAttrLine(key string, value interface{}, usedInBlock bool) string {
 		var interfaceItems []map[string]interface{}
 
 		for _, item := range value.([]interface{}) {
-			switch item.(type) {
+
+			switch item := item.(type) {
 			case string:
-				stringItems = append(stringItems, item.(string))
+				stringItems = append(stringItems, item)
 			case map[string]interface{}:
-				interfaceItems = append(interfaceItems, item.(map[string]interface{}))
+				interfaceItems = append(interfaceItems, item)
 			case float64:
-				intItems = append(intItems, int(item.(float64)))
+				intItems = append(intItems, int(item))
 			}
 		}
 		if len(stringItems) > 0 {

--- a/testdata/terraform/cloudflare_ruleset_zone_http_request_firewall_custom/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_http_request_firewall_custom/test.tf
@@ -10,7 +10,7 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     expression  = "(http.request.uri.path contains \"/filters\")"
     action_parameters {
       rules = {
-        efb7b8c949ac4650a09736fc376e9aee = "062a7840e0cb47f7b36acd2d507ce584, 5cLhGXtTafjwPkdy8fmW5QvPiokBuZhi"
+        "efb7b8c949ac4650a09736fc376e9aee" = "062a7840e0cb47f7b36acd2d507ce584, 5cLhGXtTafjwPkdy8fmW5QvPiokBuZhi"
       }
     }
     logging {

--- a/testdata/terraform/cloudflare_waf_override/test.tf
+++ b/testdata/terraform/cloudflare_waf_override/test.tf
@@ -1,7 +1,7 @@
 resource "cloudflare_waf_override" "terraform_managed_resource" {
   description = "Enable Cloudflare Magento ruleset for shop.example.com"
   groups = {
-    ea8687e59929c1fd05ba97574ad43f77 = "default"
+    "ea8687e59929c1fd05ba97574ad43f77" = "default"
   }
   paused   = false
   priority = 1
@@ -11,7 +11,7 @@ resource "cloudflare_waf_override" "terraform_managed_resource" {
     simulate  = "disable"
   }
   rules = {
-    100015 = "disable"
+    "100015" = "disable"
   }
   urls    = ["shop.example.com/*"]
   zone_id = "0da42c8d2132a9ddaf714f9e7c920711"


### PR DESCRIPTION
Add a check for types of `map[string]interface{}`. We are looking to see if the the key contains a number, if it does, we need to wrap it in quotes.