### PR TITLE
Added the option to use an existing terraform installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,17 @@ Available Commands:
   version     Print the version number of cf-terraforming
 
 Flags:
-  -a, --account string         Use specific account ID for commands
-  -c, --config string          Path to configuration file (default is $HOME/.cf-terraforming.yaml)
-  -e, --email string           API Email address associated with your account
-  -h, --help                   Help for cf-terraforming
-  -k, --key string             API Key generated on the 'My Profile' page. See: https://dash.cloudflare.com/profile
-      --resource-type string   Which resource you wish to generate
-  -t, --token string           API Token
-  -v, --verbose                Specify verbose output (same as setting log level to debug)
-  -z, --zone string            Limit the export to a single zone ID
+  -a, --account string                  Use specific account ID for commands
+  -c, --config string                   Path to configuration file (default is $HOME/.cf-terraforming.yaml)
+  -e, --email string                    API Email address associated with your account
+  -h, --help                            Help for cf-terraforming
+  -k, --key string                      API Key generated on the 'My Profile' page. See: https://dash.cloudflare.com/profile
+      --resource-type string            Which resource you wish to generate
+      --terraform-binary-path string    Path to an existing Terraform binary (otherwise, one will be downloaded)
+      --terraform-install-path string   Path to an initialized Terraform working directory (default ".")
+  -t, --token string                    API Token
+  -v, --verbose                         Specify verbose output (same as setting log level to debug)
+  -z, --zone string                     Limit the export to a single zone ID
 
 Use "cf-terraforming [command] --help" for more information about a command.
 ```

--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -45,7 +45,7 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 
 		var execPath, workingDir string
 		workingDir = viper.GetString("terraform-install-path")
-		execPath = viper.GetString("terraform-path")
+		execPath = viper.GetString("terraform-binary-path")
 
 		//Install terraform if no existing installation was provided
 		if execPath == "" {

--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -73,6 +73,7 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 
 		// Setup and configure Terraform to operate in the temporary directory where
 		// the provider is already configured.
+		log.Debugf("initializing Terraform in %s", workingDir)
 		tf, err := tfexec.NewTerraform(workingDir, execPath)
 		if err != nil {
 			log.Fatal(err)

--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -43,32 +43,32 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 		zoneID = viper.GetString("zone")
 		accountID = viper.GetString("account")
 
-		tmpDir, err := ioutil.TempDir("", "tfinstall")
-		if err != nil {
-			log.Fatal(err)
-		}
-		defer os.RemoveAll(tmpDir)
+		var execPath, workingDir string
+		workingDir = viper.GetString("terraform-install-path")
+		execPath = viper.GetString("terraform-path")
 
-		installer := &releases.ExactVersion{
-			Product: product.Terraform,
-			Version: version.Must(version.NewVersion("1.0.6")),
-		}
+		//Install terraform if no existing installation was provided
+		if execPath == "" {
+			tmpDir, err := ioutil.TempDir("", "tfinstall")
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer os.RemoveAll(tmpDir)
 
-		execPath, err := installer.Install(context.Background())
-		if err != nil {
-			log.Fatalf("error installing Terraform: %s", err)
+			installer := &releases.ExactVersion{
+				Product: product.Terraform,
+				Version: version.Must(version.NewVersion("1.0.6")),
+			}
+
+			execPath, err = installer.Install(context.Background())
+			if err != nil {
+				log.Fatalf("error installing Terraform: %s", err)
+			}
 		}
 
 		// Setup and configure Terraform to operate in the temporary directory where
 		// the provider is already configured.
-		workingDir := viper.GetString("terraform-install-path")
-		log.Debugf("initializing Terraform in %s", workingDir)
 		tf, err := tfexec.NewTerraform(workingDir, execPath)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		err = tf.Init(context.Background(), tfexec.Upgrade(true))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -47,7 +47,7 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 		workingDir = viper.GetString("terraform-install-path")
 		execPath = viper.GetString("terraform-binary-path")
 
-		//Install terraform if no existing installation was provided
+		//Download terraform if no existing binary was provided
 		if execPath == "" {
 			tmpDir, err := ioutil.TempDir("", "tfinstall")
 			if err != nil {

--- a/internal/app/cf-terraforming/cmd/root.go
+++ b/internal/app/cf-terraforming/cmd/root.go
@@ -9,7 +9,7 @@ import (
 )
 
 var log = logrus.New()
-var cfgFile, zoneID, hostname, apiEmail, apiKey, apiToken, accountID, terraformInstallPath string
+var cfgFile, zoneID, hostname, apiEmail, apiKey, apiToken, accountID, terraformInstallPath, terraformPath string
 var verbose bool
 var api *cloudflare.API
 var terraformImportCmdPrefix = "terraform import"
@@ -103,11 +103,18 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&resourceType, "resource-type", "", "Which resource you wish to generate")
 
-	rootCmd.PersistentFlags().StringVar(&terraformInstallPath, "terraform-install-path", ".", "Path to the Terraform installation")
+	rootCmd.PersistentFlags().StringVar(&terraformInstallPath, "terraform-install-path", ".", "Path where Terraform will be installed (if you don't have it)")
 
 	if err = viper.BindPFlag("terraform-install-path", rootCmd.PersistentFlags().Lookup("terraform-install-path")); err != nil {
 		log.Fatal(err)
 	}
+
+	rootCmd.PersistentFlags().StringVar(&terraformPath, "terraform-path", "", "Path to an existing Terraform installation (if you already have it)")
+
+	if err = viper.BindPFlag("terraform-path", rootCmd.PersistentFlags().Lookup("terraform-path")); err != nil {
+		log.Fatal(err)
+	}
+
 	if err = viper.BindEnv("terraform-install-path", "CLOUDFLARE_TERRAFORM_INSTALL_PATH"); err != nil {
 		log.Fatal(err)
 	}

--- a/internal/app/cf-terraforming/cmd/root.go
+++ b/internal/app/cf-terraforming/cmd/root.go
@@ -9,7 +9,7 @@ import (
 )
 
 var log = logrus.New()
-var cfgFile, zoneID, hostname, apiEmail, apiKey, apiToken, accountID, terraformInstallPath, terraformPath string
+var cfgFile, zoneID, hostname, apiEmail, apiKey, apiToken, accountID, terraformInstallPath, terraformBinaryPath string
 var verbose bool
 var api *cloudflare.API
 var terraformImportCmdPrefix = "terraform import"
@@ -103,15 +103,15 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&resourceType, "resource-type", "", "Which resource you wish to generate")
 
-	rootCmd.PersistentFlags().StringVar(&terraformInstallPath, "terraform-install-path", ".", "Path where Terraform will be installed (if you don't have it)")
+	rootCmd.PersistentFlags().StringVar(&terraformInstallPath, "terraform-install-path", ".", "Path to an initialized Terraform working directory")
 
 	if err = viper.BindPFlag("terraform-install-path", rootCmd.PersistentFlags().Lookup("terraform-install-path")); err != nil {
 		log.Fatal(err)
 	}
 
-	rootCmd.PersistentFlags().StringVar(&terraformPath, "terraform-path", "", "Path to an existing Terraform installation (if you already have it)")
+	rootCmd.PersistentFlags().StringVar(&terraformBinaryPath, "terraform-binary-path", "", "Path to an existing Terraform binary (otherwise, one will be downloaded)")
 
-	if err = viper.BindPFlag("terraform-path", rootCmd.PersistentFlags().Lookup("terraform-path")); err != nil {
+	if err = viper.BindPFlag("terraform-binary-path", rootCmd.PersistentFlags().Lookup("terraform-binary-path")); err != nil {
 		log.Fatal(err)
 	}
 


### PR DESCRIPTION
Even if Terraform is already installed, cf-terraforming always performs a new installation.
For single executions, that's fine.
However, when executing it multiple times or in a script, the installations can take up a lot of time, processing power and disk space.

We've created a new flag ("terraform-path") that, when supplied, skips the installation phase.
Example:
`./cf-terraforming generate --resource-type=cloudflare_zone --account <accountID> -t <token> --terraform-path '~/bin/terraform' -v`

If the flag is not supplied, the program assumes terraform is not installed and reverts to the old behaviour.