### PR TITLE
Escape special TF characters we might find %{ or ${

### DIFF
--- a/testdata/cloudflare/cloudflare_filter.yaml
+++ b/testdata/cloudflare/cloudflare_filter.yaml
@@ -18,17 +18,17 @@ interactions:
         "result": [
           {
             "id": "372e67954025e0ba6aaa6d586b9e0b61",
-            "expression": "(http.request.uri.path ~ \".*wp-login.php\" or http.request.uri.path ~ \".*xmlrpc.php\") and ip.addr ne 172.16.22.155",
+            "expression": "(http.request.uri.path ~ \".*wp-login.php\" or http.request.uri.path ~ \".*xmlrpc.php\") and (http.user_agent contains \"${jndi\" or \"%{other}\") and ip.addr ne 172.16.22.155",
             "paused": false,
             "description": "Restrict access from these browsers on this address range.",
             "ref": "FIL-100"
           }
         ],
         "result_info": {
-          "page": 1,
+         "page": 1,
           "per_page": 100,
-          "count": 1,
-          "total_count": 1,
+          "count": 2,
+          "total_count": 2,
           "total_pages": 1
         }
       }

--- a/testdata/terraform/cloudflare_filter/test.tf
+++ b/testdata/terraform/cloudflare_filter/test.tf
@@ -1,6 +1,6 @@
 resource "cloudflare_filter" "terraform_managed_resource" {
   description = "Restrict access from these browsers on this address range."
-  expression  = "(http.request.uri.path ~ \".*wp-login.php\" or http.request.uri.path ~ \".*xmlrpc.php\") and ip.addr ne 172.16.22.155"
+  expression  = "(http.request.uri.path ~ \".*wp-login.php\" or http.request.uri.path ~ \".*xmlrpc.php\") and (http.user_agent contains \"$${jndi\" or \"%%{other}\") and ip.addr ne 172.16.22.155"
   paused      = false
   ref         = "FIL-100"
   zone_id     = "0da42c8d2132a9ddaf714f9e7c920711"


### PR DESCRIPTION
If we find special characters when downloading TF, we should escape them. 
Terraform special characters can be escaped by doubling up on the value $$ or %%.