### PR TITLE
fix nil pointer exception in cache rules transformation

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -946,12 +946,16 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 							}
 							// Cache Rules transformation
 							if jsonStructData[i].(map[string]interface{})["phase"] == "http_request_cache_settings" {
-								if c, ok := rules.([]interface{})[ruleCounter].(map[string]interface{})["action_parameters"].(map[string]interface{})["cache_key"].(map[string]interface{})["custom_key"]; ok {
-									if s, sok := c.(map[string]interface{})["query_string"].(map[string]interface{})["include"]; sok && s == "*" {
-										rules.([]interface{})[ruleCounter].(map[string]interface{})["action_parameters"].(map[string]interface{})["cache_key"].(map[string]interface{})["custom_key"].(map[string]interface{})["query_string"].(map[string]interface{})["include"] = []interface{}{"*"}
-									}
-									if s, sok := c.(map[string]interface{})["query_string"].(map[string]interface{})["exclude"]; sok && s == "*" {
-										rules.([]interface{})[ruleCounter].(map[string]interface{})["action_parameters"].(map[string]interface{})["cache_key"].(map[string]interface{})["custom_key"].(map[string]interface{})["query_string"].(map[string]interface{})["exclude"] = []interface{}{"*"}
+								if ck, ok := rules.([]interface{})[ruleCounter].(map[string]interface{})["action_parameters"].(map[string]interface{})["cache_key"]; ok {
+									if c, cok := ck.(map[string]interface{})["custom_key"]; cok {
+										if qs, qok := c.(map[string]interface{})["query_string"]; qok {
+											if s, sok := qs.(map[string]interface{})["include"]; sok && s == "*" {
+												rules.([]interface{})[ruleCounter].(map[string]interface{})["action_parameters"].(map[string]interface{})["cache_key"].(map[string]interface{})["custom_key"].(map[string]interface{})["query_string"].(map[string]interface{})["include"] = []interface{}{"*"}
+											}
+											if s, sok := qs.(map[string]interface{})["exclude"]; sok && s == "*" {
+												rules.([]interface{})[ruleCounter].(map[string]interface{})["action_parameters"].(map[string]interface{})["cache_key"].(map[string]interface{})["custom_key"].(map[string]interface{})["query_string"].(map[string]interface{})["exclude"] = []interface{}{"*"}
+											}
+										}
 									}
 								}
 							}

--- a/testdata/cloudflare/cloudflare_ruleset_http_request_cache_settings.yaml
+++ b/testdata/cloudflare/cloudflare_ruleset_http_request_cache_settings.yaml
@@ -97,6 +97,23 @@ interactions:
                   },
                   "origin_error_page_passthru": true
                 }
+              },
+              {
+                "id": "e5f1bd1386b4464aa8d726ba1e0d51ad",
+                "version": "2",
+                "action": "set_cache_settings",
+                "expression": "(http.host eq \"example.com\")",
+                "description": "/status/202",
+                "last_updated": "2022-09-21T16:36:00.999083Z",
+                "ref": "e5f1bd1386b4464aa8d726ba1e0d51ad",
+                "enabled": true,
+                "action_parameters": {
+                  "cache": false,
+                  "edge_ttl": {
+                    "mode": "override_origin",
+                    "default": 60
+                  }
+                }
               }
             ],
             "last_updated": "2022-09-28T17:21:21.510301Z",

--- a/testdata/terraform/cloudflare_ruleset_http_request_cache_settings/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_http_request_cache_settings/test.tf
@@ -41,4 +41,17 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
       respect_strong_etags       = true
     }
   }
+  rules {
+    action      = "set_cache_settings"
+    description = "/status/202"
+    enabled     = true
+    expression  = "(http.host eq \"example.com\")"
+    action_parameters {
+      edge_ttl {
+        default = 60
+        mode    = "override_origin"
+      }
+      cache = false
+    }
+  }
 }


### PR DESCRIPTION
There were some assumptions made that certain keys existed when cache rules were present. These assumptions were incorrect and resulted in nil pointer exceptions. Now we check for each optional key before we try to make the transform. 