### PR TITLE
once we find an "id" use that as the ParentID for the rest of the rule

### DIFF
--- a/internal/app/cf-terraforming/cmd/util.go
+++ b/internal/app/cf-terraforming/cmd/util.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
-	"github.com/google/uuid"
 	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -221,21 +220,23 @@ func nestBlocks(schemaBlock *tfjson.SchemaBlock, structData map[string]interface
 					case []interface{}:
 						var previousNextedBlockOutput string
 						for _, nestedItem := range s.([]interface{}) {
-							parentID, exists := nestedItem.(map[string]interface{})["id"]
+							_, exists := nestedItem.(map[string]interface{})["id"]
+							if exists {
+								parentID = nestedItem.(map[string]interface{})["id"].(string)
+							}
 							if !exists {
 								// if we fail to find an ID, we tag the current element with a uuid
 								log.Debugf("id not found for nestedItem %#v using uuid terraform_internal_id", nestedItem)
-								parentID = uuid.New().String()
 								nestedItem.(map[string]interface{})["terraform_internal_id"] = parentID
 							}
 
-							nestedBlockOutput += nestBlocks(schemaBlock.NestedBlocks[block].Block, nestedItem.(map[string]interface{}), parentID.(string), indexedNestedBlocks)
+							nestedBlockOutput += nestBlocks(schemaBlock.NestedBlocks[block].Block, nestedItem.(map[string]interface{}), parentID, indexedNestedBlocks)
 
 							if previousNextedBlockOutput != nestedBlockOutput {
 								previousNextedBlockOutput = nestedBlockOutput
 								// The indexedNestedBlocks maps helps us know which parent we're rendering the nested block for
 								// So we append the current child's output to it, for when we render it out later
-								indexedNestedBlocks[parentID.(string)] = append(indexedNestedBlocks[parentID.(string)], nestedBlockOutput)
+								indexedNestedBlocks[parentID] = append(indexedNestedBlocks[parentID], nestedBlockOutput)
 							}
 						}
 

--- a/testdata/cloudflare/cloudflare_ruleset_http_request_cache_settings.yaml
+++ b/testdata/cloudflare/cloudflare_ruleset_http_request_cache_settings.yaml
@@ -114,6 +114,31 @@ interactions:
                     "default": 60
                   }
                 }
+              },
+              {
+                "id": "cd89ae000de64730bd61651c1b1f7f8c",
+                "version": "1",
+                "action": "set_cache_settings",
+                "expression": "(http.host eq \"example.com\")",
+                "description": "test cache rule 2",
+                "last_updated": "2023-01-12T15:11:57.591876Z",
+                "ref": "cd89ae000de64730bd61651c1b1f7f8c",
+                "enabled": true,
+                "action_parameters": {
+                  "cache": true,
+                  "edge_ttl": {
+                    "mode": "respect_origin",
+                    "status_code_ttl": [
+                      {
+                        "status_code_range": {
+                          "from": 100,
+                          "to": 200
+                        },
+                        "value": 300
+                      }
+                    ]
+                  }
+                }
               }
             ],
             "last_updated": "2022-09-28T17:21:21.510301Z",

--- a/testdata/terraform/cloudflare_ruleset_http_request_cache_settings/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_http_request_cache_settings/test.tf
@@ -54,4 +54,23 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
       cache = false
     }
   }
+  rules {
+    action      = "set_cache_settings"
+    description = "test cache rule 2"
+    enabled     = true
+    expression  = "(http.host eq \"example.com\")"
+    action_parameters {
+      edge_ttl {
+        status_code_ttl {
+          value = 300
+          status_code_range {
+            from = 100
+            to   = 200
+          }
+        }
+        mode = "respect_origin"
+      }
+      cache = true
+    }
+  }
 }


### PR DESCRIPTION
We found that `status_code_range` was being omitted from the terraform. I found that it was due sub elements of a rule being assigned to a new ParentID instead of inheriting the `id` of the rule as its ParentID. This change makes the `id` element of a rule the parentID for the rest of that rule nested loops. 