### PR TITLE
util: prevent --account and --zone being used together

### DIFF
--- a/internal/app/cf-terraforming/cmd/util.go
+++ b/internal/app/cf-terraforming/cmd/util.go
@@ -73,7 +73,7 @@ func sharedPreRun(cmd *cobra.Command, args []string) {
 	hostname = viper.GetString("hostname")
 
 	if accountID != "" && zoneID != "" {
-		log.Debug("--account and --zone are mutually exclusive, support for both is deprecated")
+		log.Fatal("--account and --zone are mutually exclusive, support for both is deprecated")
 	}
 
 	if apiToken = viper.GetString("token"); apiToken == "" {
@@ -98,15 +98,6 @@ func sharedPreRun(cmd *cobra.Command, args []string) {
 	}
 
 	var options []cloudflare.Option
-
-	if accountID != "" {
-		log.WithFields(logrus.Fields{
-			"account_id": accountID,
-		}).Debug("configuring Cloudflare API with account")
-
-		// Organization ID was passed, use it to configure the API
-		options = append(options, cloudflare.UsingAccount(accountID))
-	}
 
 	if hostname != "" {
 		options = append(options, cloudflare.BaseURL("https://"+hostname+"/client/v4"))


### PR DESCRIPTION
These flags are mutually exclusive and are used to determine which level (zone or account) resources should be exported. The previous behaviour would discard zone in the event of a collision.

Last time we tried this in #356, we still had the dependency on the global `account_id`. That has now been removed (since cloudflare-go [0.57.0](https://github.com/cloudflare/cloudflare-go/blob/master/CHANGELOG.md#0570-december-22nd-2022)) and now requires explicitly identifiers for all Workers endpoints. Worker Routes still use the zone levels APIs while everything else is account level based.

cc @manatarms @jafowler 