### PR TITLE
Improving block nesting logic to handle crazy rulesets

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
-	"github.com/google/uuid"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hc-install/product"
 	"github.com/hashicorp/hc-install/releases"
@@ -1224,7 +1223,7 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 				}
 			}
 
-			output += nestBlocks(r.Block, jsonStructData[i].(map[string]interface{}), uuid.New().String(), map[string][]string{})
+			output += buildBlocks(r.Block, jsonStructData[i].(map[string]interface{}))
 			output += "}\n\n"
 		}
 

--- a/testdata/cloudflare/cloudflare_ruleset_http_request_cache_settings.yaml
+++ b/testdata/cloudflare/cloudflare_ruleset_http_request_cache_settings.yaml
@@ -53,6 +53,7 @@ interactions:
             "description": "",
             "kind": "zone",
             "version": "3",
+            "phase": "http_request_cache_settings",
             "rules": [
               {
                 "id": "0f24aab3002347a9a4ac01520e6893d0",
@@ -70,8 +71,18 @@ interactions:
                     "default": 30,
                     "status_code_ttl": [
                       {
-                        "status_code": 100,
-                        "value": 30
+                        "status_code_range": {
+                          "from": 101,
+                          "to": 103
+                        },
+                        "value": 1
+                      },
+                      {
+                        "status_code_range": {
+                          "from": 106,
+                          "to": 110
+                        },
+                        "value": 1
                       }
                     ]
                   },
@@ -99,23 +110,6 @@ interactions:
                 }
               },
               {
-                "id": "e5f1bd1386b4464aa8d726ba1e0d51ad",
-                "version": "2",
-                "action": "set_cache_settings",
-                "expression": "(http.host eq \"example.com\")",
-                "description": "/status/202",
-                "last_updated": "2022-09-21T16:36:00.999083Z",
-                "ref": "e5f1bd1386b4464aa8d726ba1e0d51ad",
-                "enabled": true,
-                "action_parameters": {
-                  "cache": false,
-                  "edge_ttl": {
-                    "mode": "override_origin",
-                    "default": 60
-                  }
-                }
-              },
-              {
                 "id": "cd89ae000de64730bd61651c1b1f7f8c",
                 "version": "1",
                 "action": "set_cache_settings",
@@ -131,18 +125,65 @@ interactions:
                     "status_code_ttl": [
                       {
                         "status_code_range": {
-                          "from": 100,
-                          "to": 200
+                          "from": 1,
+                          "to": 2
                         },
-                        "value": 300
+                        "value": 10
+                      },
+                      {
+                        "status_code_range": {
+                          "from": 3,
+                          "to": 4
+                        },
+                        "value": 1
                       }
                     ]
                   }
                 }
+              },
+              {
+                "id": "794367d03d42438ba24649adff739c9c",
+                "version": "5",
+                "action": "set_cache_settings",
+                "expression": "(http.host eq \"example.com\")",
+                "description": "test cache rule",
+                "last_updated": "2023-01-20T12:13:32.833868Z",
+                "ref": "794367d03d42438ba24649adff739c9c",
+                "enabled": false,
+                "action_parameters": {
+                  "cache": true,
+                  "edge_ttl": {
+                    "mode": "override_origin",
+                    "default": 1,
+                    "status_code_ttl": [
+                      {
+                        "status_code": 100,
+                        "value": 5
+                      }
+                    ]
+                  },
+                  "browser_ttl": {
+                    "mode": "respect_origin"
+                  },
+                  "serve_stale": {
+                    "disable_stale_while_updating": true
+                  },
+                  "respect_strong_etags": true,
+                  "cache_key": {
+                    "cache_by_device_type": true,
+                    "custom_key": {
+                      "query_string": {
+                        "include": "*"
+                      },
+                      "host": {
+                        "resolved": false
+                      }
+                    }
+                  }
+                }
               }
             ],
-            "last_updated": "2022-09-28T17:21:21.510301Z",
-            "phase": "http_request_cache_settings"
+            "last_updated": "2022-09-28T17:21:21.510301Z"
           },
           "success": true,
           "errors": [],

--- a/testdata/terraform/cloudflare_custom_hostname/test.tf
+++ b/testdata/terraform/cloudflare_custom_hostname/test.tf
@@ -6,16 +6,16 @@ resource "cloudflare_custom_hostname" "terraform_managed_resource" {
   hostname             = "app.example.com"
   zone_id              = "0da42c8d2132a9ddaf714f9e7c920711"
   ssl {
-    settings {
-      ciphers         = ["ECDHE-RSA-AES128-GCM-SHA256", "AES128-SHA"]
-      http2           = "on"
-      min_tls_version = "1.2"
-    }
     certificate_authority = "digicert"
     custom_certificate    = "-----BEGIN CERTIFICATE-----\\nMIIFJDCCBAygAwIBAgIQD0ifmj/Yi5NP/2gdUySbfzANBgkqhkiG9w0BAQsFADBN\\nMQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMScwJQYDVQQDEx5E...SzSHfXp5lnu/3V08I72q1QNzOCgY1XeL4GKVcj4or6cT6tX6oJH7ePPmfrBfqI/O\\nOeH8gMJ+FuwtXYEPa4hBf38M5eU5xWG7\\n-----END CERTIFICATE-----\\n"
     custom_key            = "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmG\ndtcGbg/1CGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKn\nabIRuGvBKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpid\ntnKX/a+50GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+py\nFxIXjbEIdZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pE\newooaeO2izNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABAoIBACbhTYXBZYKmYPCb\nHBR1IBlCQA2nLGf0qRuJNJZg5iEzXows/6tc8YymZkQE7nolapWsQ+upk2y5Xdp/\naxiuprIs9JzkYK8Ox0r+dlwCG1kSW+UAbX0bQ/qUqlsTvU6muVuMP8vZYHxJ3wmb\n+ufRBKztPTQ/rYWaYQcgC0RWI20HTFBMxlTAyNxYNWzX7RKFkGVVyB9RsAtmcc8g\n+j4OdosbfNoJPS0HeIfNpAznDfHKdxDk2Yc1tV6RHBrC1ynyLE9+TaflIAdo2MVv\nKLMLq51GqYKtgJFIlBRPQqKoyXdz3fGvXrTkf/WY9QNq0J1Vk5ERePZ54mN8iZB7\n9lwy/AkCgYEA6FXzosxswaJ2wQLeoYc7ceaweX/SwTvxHgXzRyJIIT0eJWgx13Wo\n/WA3Iziimsjf6qE+SI/8laxPp2A86VMaIt3Z3mJN/CqSVGw8LK2AQst+OwdPyDMu\niacE8lj/IFGC8mwNUAb9CzGU3JpU4PxxGFjS/eMtGeRXCWkK4NE+G08CgYEA1Kp9\nN2JrVlqUz+gAX+LPmE9OEMAS9WQSQsfCHGogIFDGGcNf7+uwBM7GAaSJIP01zcoe\nVAgWdzXCv3FLhsaZoJ6RyLOLay5phbu1iaTr4UNYm5WtYTzMzqh8l1+MFFDl9xDB\nvULuCIIrglM5MeS/qnSg1uMoH2oVPj9TVst/ir8CgYEAxrI7Ws9Zc4Bt70N1As+U\nlySjaEVZCMkqvHJ6TCuVZFfQoE0r0whdLdRLU2PsLFP+q7qaeZQqgBaNSKeVcDYR\n9B+nY/jOmQoPewPVsp/vQTCnE/R81spu0mp0YI6cIheT1Z9zAy322svcc43JaWB7\nmEbeqyLOP4Z4qSOcmghZBSECgYACvR9Xs0DGn+wCsW4vze/2ei77MD4OQvepPIFX\ndFZtlBy5ADcgE9z0cuVB6CiL8DbdK5kwY9pGNr8HUCI03iHkW6Zs+0L0YmihfEVe\nPG19PSzK9CaDdhD9KFZSbLyVFmWfxOt50H7YRTTiPMgjyFpfi5j2q348yVT0tEQS\nfhRqaQKBgAcWPokmJ7EbYQGeMbS7HC8eWO/RyamlnSffdCdSc7ue3zdVJxpAkQ8W\nqu80pEIF6raIQfAf8MXiiZ7auFOSnHQTXUbhCpvDLKi0Mwq3G8Pl07l+2s6dQG6T\nlv6XTQaMyf6n1yjzL+fzDrH3qXMxHMO/b13EePXpDMpY7HQpoLDi\n-----END RSA PRIVATE KEY-----\n"
     method                = "http"
     type                  = "dv"
     wildcard              = false
+    settings {
+      ciphers         = ["ECDHE-RSA-AES128-GCM-SHA256", "AES128-SHA"]
+      http2           = "on"
+      min_tls_version = "1.2"
+    }
   }
 }

--- a/testdata/terraform/cloudflare_page_rule/test.tf
+++ b/testdata/terraform/cloudflare_page_rule/test.tf
@@ -4,6 +4,9 @@ resource "cloudflare_page_rule" "terraform_managed_resource" {
   target   = "*example.com/images/*"
   zone_id  = "0da42c8d2132a9ddaf714f9e7c920711"
   actions {
+    browser_cache_ttl    = 1800
+    disable_apps         = true
+    host_header_override = "not-example.com"
     cache_key_fields {
       cookie {
         check_presence = ["x-some-header"]
@@ -37,8 +40,5 @@ resource "cloudflare_page_rule" "terraform_managed_resource" {
       codes = "300-399"
       ttl   = 0
     }
-    browser_cache_ttl    = 1800
-    disable_apps         = true
-    host_header_override = "not-example.com"
   }
 }

--- a/testdata/terraform/cloudflare_rate_limit/test.tf
+++ b/testdata/terraform/cloudflare_rate_limit/test.tf
@@ -5,12 +5,12 @@ resource "cloudflare_rate_limit" "terraform_managed_resource" {
   threshold           = 10
   zone_id             = "0da42c8d2132a9ddaf714f9e7c920711"
   action {
+    mode    = "ban"
+    timeout = 3600
     response {
       body         = "{\"response\":\"your request has been rate limited\"}"
       content_type = "application/json"
     }
-    mode    = "ban"
-    timeout = 3600
   }
   match {
     request {

--- a/testdata/terraform/cloudflare_ruleset_override_remapping_disabled/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_override_remapping_disabled/test.tf
@@ -9,7 +9,11 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     enabled     = false
     expression  = "(http.cookie eq \"jb_testing=true\")"
     action_parameters {
+      id      = "efb7b8c949ac4650a09736fc376e9aee"
+      version = "latest"
       overrides {
+        action = "log"
+        status = "disabled"
         categories {
           category = "paranoia-level-2"
           status   = "disabled"
@@ -18,11 +22,7 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
           id     = "6179ae15870a4bb7b2d480d4843b323c"
           status = "disabled"
         }
-        action = "log"
-        status = "disabled"
       }
-      id      = "efb7b8c949ac4650a09736fc376e9aee"
-      version = "latest"
     }
   }
 }

--- a/testdata/terraform/cloudflare_ruleset_override_remapping_enabled/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_override_remapping_enabled/test.tf
@@ -9,7 +9,11 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     enabled     = false
     expression  = "(http.cookie eq \"jb_testing=true\")"
     action_parameters {
+      id      = "efb7b8c949ac4650a09736fc376e9aee"
+      version = "latest"
       overrides {
+        action = "log"
+        status = "enabled"
         categories {
           category = "paranoia-level-2"
           status   = "enabled"
@@ -18,11 +22,7 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
           id     = "6179ae15870a4bb7b2d480d4843b323c"
           status = "enabled"
         }
-        action = "log"
-        status = "enabled"
       }
-      id      = "efb7b8c949ac4650a09736fc376e9aee"
-      version = "latest"
     }
   }
 }

--- a/testdata/terraform/cloudflare_ruleset_zone/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone/test.tf
@@ -8,14 +8,14 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     enabled    = true
     expression = "true"
     action_parameters {
+      id      = "70339d97bdb34195bbf054b1ebe81f76"
+      version = "latest"
       overrides {
         rules {
           id     = "78723a9e0c7c4c6dbec5684cb766231d"
           status = "enabled"
         }
       }
-      id      = "70339d97bdb34195bbf054b1ebe81f76"
-      version = "latest"
     }
   }
 }

--- a/testdata/terraform/cloudflare_ruleset_zone_ddos_l7/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_ddos_l7/test.tf
@@ -9,11 +9,11 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     enabled     = true
     expression  = "true"
     action_parameters {
+      id      = "4d21379b4f9f4bb088e0729962c8b3cf"
+      version = "latest"
       overrides {
         sensitivity_level = "medium"
       }
-      id      = "4d21379b4f9f4bb088e0729962c8b3cf"
-      version = "latest"
     }
   }
 }

--- a/testdata/terraform/cloudflare_ruleset_zone_http_request_firewall_managed/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_http_request_firewall_managed/test.tf
@@ -9,6 +9,8 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     enabled     = false
     expression  = "(http.cookie eq \"jb_testing=true\")"
     action_parameters {
+      id      = "efb7b8c949ac4650a09736fc376e9aee"
+      version = "latest"
       overrides {
         rules {
           action = "block"
@@ -71,8 +73,6 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
           id     = "34158d546873469a8f8ccee19139627b"
         }
       }
-      id      = "efb7b8c949ac4650a09736fc376e9aee"
-      version = "latest"
     }
   }
 }

--- a/testdata/terraform/cloudflare_ruleset_zone_http_request_sanitize/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_http_request_sanitize/test.tf
@@ -8,14 +8,14 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     enabled    = true
     expression = "true"
     action_parameters {
+      id      = "70339d97bdb34195bbf054b1ebe81f76"
+      version = "latest"
       overrides {
         rules {
           id     = "78723a9e0c7c4c6dbec5684cb766231d"
           status = "enabled"
         }
       }
-      id      = "70339d97bdb34195bbf054b1ebe81f76"
-      version = "latest"
     }
   }
 }

--- a/testdata/terraform/cloudflare_zone_settings_override/test.tf
+++ b/testdata/terraform/cloudflare_zone_settings_override/test.tf
@@ -1,18 +1,6 @@
 resource "cloudflare_zone_settings_override" "terraform_managed_resource" {
   zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
   settings {
-    minify {
-      css  = "on"
-      html = "off"
-      js   = "off"
-    }
-    security_header {
-      enabled            = true
-      include_subdomains = true
-      max_age            = 86400
-      nosniff            = true
-      preload            = true
-    }
     always_online               = "on"
     always_use_https            = "off"
     automatic_https_rewrites    = "on"
@@ -57,5 +45,17 @@ resource "cloudflare_zone_settings_override" "terraform_managed_resource" {
     webp                        = "off"
     websockets                  = "on"
     zero_rtt                    = "off"
+    minify {
+      css  = "on"
+      html = "off"
+      js   = "off"
+    }
+    security_header {
+      enabled            = true
+      include_subdomains = true
+      max_age            = 86400
+      nosniff            = true
+      preload            = true
+    }
   }
 }


### PR DESCRIPTION
Hey folks,

I'm dropping this PR to improve our block nesting logic. Instead of looping through the attribute struct every time we move into another level of the schema, I decided to separate this into two steps.

1. Flatten out the API response and create a queryable map with all the attributes
i.e., `attributes["rules.2.action_parameters.edge_ttl.status_code_ttl.0.status_code_range"]`
This is good for us, because when we traverse the schema, we can easily build these queries from block names and array iterators.

2. Traverse the schema and query for the attributes