### PR TITLE
fix Argo Smart Routing overriding Tiered Caching

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -288,9 +288,9 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 				log.Fatal(err)
 			}
 
-			for _, b := range jsonStructData {
+			for i, b := range jsonStructData {
 				key := b.(map[string]interface{})["id"].(string)
-				jsonStructData[0].(map[string]interface{})[key] = jsonStructData[0].(map[string]interface{})["value"]
+				jsonStructData[0].(map[string]interface{})[key] = jsonStructData[i].(map[string]interface{})["value"]
 			}
 		case "cloudflare_api_shield":
 			jsonPayload := []cloudflare.APIShield{}

--- a/testdata/cloudflare/cloudflare_argo.yaml
+++ b/testdata/cloudflare/cloudflare_argo.yaml
@@ -14,7 +14,7 @@ interactions:
       {
         "result": {
           "id": "smart_routing",
-          "value": "off",
+          "value": "on",
           "modified_on": "2021-08-29T22:07:38.044691Z",
           "editable": true
         },

--- a/testdata/terraform/cloudflare_argo/test.tf
+++ b/testdata/terraform/cloudflare_argo/test.tf
@@ -1,5 +1,5 @@
 resource "cloudflare_argo" "terraform_managed_resource" {
-  smart_routing  = "off"
+  smart_routing  = "on"
   tiered_caching = "off"
   zone_id        = "0da42c8d2132a9ddaf714f9e7c920711"
 }


### PR DESCRIPTION
The resource`cloudflare_argo` is built from two API calls: `ArgoSmartRouting`, `ArgoTieredCaching`, where `ArgoSmartRouting` value were overriding `ArgoTieredCaching`.

`ArgoSmartRouting` response:
```
tjozsa@MF2N04G4FY terraform % curl 'https://api.cloudflare.com/client/v4/zones/24670de1ee826d9591121cbd94418f7b/argo/smart_routing' | jq -c '.result.value'
"on"
```

`ArgoSmartRouting` response:
```
tjozsa@MF2N04G4FY terraform % curl 'https://api.cloudflare.com/client/v4/zones/24670de1ee826d9591121cbd94418f7b/argo/tiered_caching' | jq -c '.result.value'
"off"
```

generated resource:
```
resource "cloudflare_argo" "terraform_managed_resource_smart_routing" {
  smart_routing  = "on"
  tiered_caching = "on"
  zone_id        = "24670de1ee826d9591121cbd94418f7b"
}
```
