### PR TITLE
cmd/generate: remove `cloudflare_ruleset` enabled remapping

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -833,37 +833,6 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 					for ruleCounter := range rules.([]interface{}) {
 						actionParams := rules.([]interface{})[ruleCounter].(map[string]interface{})["action_parameters"]
 						if actionParams != nil {
-							overrides := actionParams.(map[string]interface{})["overrides"]
-							if overrides != nil {
-								if overrides.(map[string]interface{})["enabled"] == true {
-									overrides.(map[string]interface{})["status"] = "enabled"
-								}
-
-								if overrides.(map[string]interface{})["enabled"] == false {
-									overrides.(map[string]interface{})["status"] = "disabled"
-								}
-
-								overrides.(map[string]interface{})["enabled"] = nil
-
-								for key := range overrides.(map[string]interface{}) {
-									overrideRules, ok := overrides.(map[string]interface{})[key].([]interface{})
-									if !ok || overrideRules == nil {
-										continue
-									}
-
-									for j := range overrideRules {
-										if overrideRules[j].(map[string]interface{})["enabled"] == true {
-											overrideRules[j].(map[string]interface{})["status"] = "enabled"
-										}
-
-										if overrideRules[j].(map[string]interface{})["enabled"] == false {
-											overrideRules[j].(map[string]interface{})["status"] = "disabled"
-										}
-
-										overrideRules[j].(map[string]interface{})["enabled"] = nil
-									}
-								}
-							}
 							// check for log custom fields that need to be transformed
 							for _, logCustomFields := range logCustomFieldsTransform {
 								// check if the field exists and make sure it has at least one element
@@ -877,6 +846,7 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 									actionParams.(map[string]interface{})[logCustomFields] = newLogCustomFields
 								}
 							}
+
 							// check if our ruleset is of action 'skip'
 							if rules.([]interface{})[ruleCounter].(map[string]interface{})["action"] == "skip" {
 								for rule := range actionParams.(map[string]interface{}) {
@@ -891,28 +861,8 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 										}
 									}
 								}
-								// do we have a logging parameter in our rule?
-								if rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"] != nil {
-									// make sure it has data
-									if rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"].(map[string]interface{})["enabled"] != nil {
-										/*
-											enabled = true -> status = 'enabled'
-											enabled = flase -> status = 'disabled'
-											Also lets only add 'status' if it doesn't already exist
-										*/
-										if rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"].(map[string]interface{})["enabled"] == true &&
-											rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"].(map[string]interface{})["status"] == nil {
-											rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"].(map[string]interface{})["status"] = "enabled"
-											delete(rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"].(map[string]interface{}), "enabled")
-										}
-										if rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"].(map[string]interface{})["enabled"] == false &&
-											rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"].(map[string]interface{})["status"] == nil {
-											rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"].(map[string]interface{})["status"] = "disabled"
-											delete(rules.([]interface{})[ruleCounter].(map[string]interface{})["logging"].(map[string]interface{}), "enabled")
-										}
-									}
-								}
 							}
+
 							// Cache Rules transformation
 							if jsonStructData[i].(map[string]interface{})["phase"] == "http_request_cache_settings" {
 								if ck, ok := rules.([]interface{})[ruleCounter].(map[string]interface{})["action_parameters"].(map[string]interface{})["cache_key"]; ok {

--- a/testdata/terraform/cloudflare_ruleset_override_remapping_disabled/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_override_remapping_disabled/test.tf
@@ -11,13 +11,13 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
         action = "log"
         categories {
           category = "paranoia-level-2"
-          status   = "disabled"
+          enabled  = false
         }
         rules {
-          id     = "6179ae15870a4bb7b2d480d4843b323c"
-          status = "disabled"
+          id      = "6179ae15870a4bb7b2d480d4843b323c"
+          enabled = false
         }
-        status = "disabled"
+        enabled = false
       }
       version = "latest"
     }

--- a/testdata/terraform/cloudflare_ruleset_override_remapping_disabled/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_override_remapping_disabled/test.tf
@@ -13,11 +13,11 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
           category = "paranoia-level-2"
           enabled  = false
         }
-        rules {
-          id      = "6179ae15870a4bb7b2d480d4843b323c"
-          enabled = false
-        }
         enabled = false
+        rules {
+          enabled = false
+          id      = "6179ae15870a4bb7b2d480d4843b323c"
+        }
       }
       version = "latest"
     }

--- a/testdata/terraform/cloudflare_ruleset_override_remapping_enabled/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_override_remapping_enabled/test.tf
@@ -11,13 +11,13 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
         action = "log"
         categories {
           category = "paranoia-level-2"
-          status   = "enabled"
+          enabled  = true
         }
         rules {
-          id     = "6179ae15870a4bb7b2d480d4843b323c"
-          status = "enabled"
+          id      = "6179ae15870a4bb7b2d480d4843b323c"
+          enabled = true
         }
-        status = "enabled"
+        enabled = true
       }
       version = "latest"
     }

--- a/testdata/terraform/cloudflare_ruleset_override_remapping_enabled/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_override_remapping_enabled/test.tf
@@ -13,11 +13,11 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
           category = "paranoia-level-2"
           enabled  = true
         }
-        rules {
-          id      = "6179ae15870a4bb7b2d480d4843b323c"
-          enabled = true
-        }
         enabled = true
+        rules {
+          enabled = true
+          id      = "6179ae15870a4bb7b2d480d4843b323c"
+        }
       }
       version = "latest"
     }

--- a/testdata/terraform/cloudflare_ruleset_zone/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone/test.tf
@@ -9,8 +9,8 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
       id = "70339d97bdb34195bbf054b1ebe81f76"
       overrides {
         rules {
-          id      = "78723a9e0c7c4c6dbec5684cb766231d"
           enabled = true
+          id      = "78723a9e0c7c4c6dbec5684cb766231d"
         }
       }
       version = "latest"

--- a/testdata/terraform/cloudflare_ruleset_zone/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone/test.tf
@@ -9,8 +9,8 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
       id = "70339d97bdb34195bbf054b1ebe81f76"
       overrides {
         rules {
-          id     = "78723a9e0c7c4c6dbec5684cb766231d"
-          status = "enabled"
+          id      = "78723a9e0c7c4c6dbec5684cb766231d"
+          enabled = true
         }
       }
       version = "latest"

--- a/testdata/terraform/cloudflare_ruleset_zone_http_request_firewall_custom/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_http_request_firewall_custom/test.tf
@@ -15,7 +15,7 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     expression   = "(http.host eq \"test.example.com\")"
     last_updated = "2022-11-24T14:24:14.756247Z"
     logging {
-      status = "enabled"
+      enabled = false
     }
   }
   rules {

--- a/testdata/terraform/cloudflare_ruleset_zone_http_request_firewall_custom/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_http_request_firewall_custom/test.tf
@@ -15,7 +15,7 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     expression   = "(http.host eq \"test.example.com\")"
     last_updated = "2022-11-24T14:24:14.756247Z"
     logging {
-      enabled = false
+      enabled = true
     }
   }
   rules {

--- a/testdata/terraform/cloudflare_ruleset_zone_http_request_sanitize/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_http_request_sanitize/test.tf
@@ -9,8 +9,8 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
       id = "70339d97bdb34195bbf054b1ebe81f76"
       overrides {
         rules {
-          id      = "78723a9e0c7c4c6dbec5684cb766231d"
           enabled = true
+          id      = "78723a9e0c7c4c6dbec5684cb766231d"
         }
       }
       version = "latest"

--- a/testdata/terraform/cloudflare_ruleset_zone_http_request_sanitize/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_http_request_sanitize/test.tf
@@ -9,8 +9,8 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
       id = "70339d97bdb34195bbf054b1ebe81f76"
       overrides {
         rules {
-          id     = "78723a9e0c7c4c6dbec5684cb766231d"
-          status = "enabled"
+          id      = "78723a9e0c7c4c6dbec5684cb766231d"
+          enabled = true
         }
       }
       version = "latest"


### PR DESCRIPTION
With the latest release of the Terraform Provider, we've migrated `cloudflare_ruleset` to the plugin framework and no longer require the `enabled => status` field remapping.