### PR TITLE
cmd/generate: Handle rewriting `uri.query.value` to empty strings 

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -1119,12 +1119,12 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 					continue
 				}
 				if attrName == "account_id" && accountID != "" {
-					writeAttrLine(attrName, accountID, resource)
+					writeAttrLine(attrName, accountID, "", resource)
 					continue
 				}
 
 				if attrName == "zone_id" && zoneID != "" && accountID == "" {
-					writeAttrLine(attrName, zoneID, resource)
+					writeAttrLine(attrName, zoneID, "", resource)
 					continue
 				}
 
@@ -1133,7 +1133,7 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 				case ty.IsPrimitiveType():
 					switch ty {
 					case cty.String, cty.Bool, cty.Number:
-						writeAttrLine(attrName, structData[attrName], resource)
+						writeAttrLine(attrName, structData[attrName], "", resource)
 						delete(structData, attrName)
 					default:
 						log.Debugf("unexpected primitive type %q", ty.FriendlyName())
@@ -1141,7 +1141,7 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 				case ty.IsCollectionType():
 					switch {
 					case ty.IsListType(), ty.IsSetType(), ty.IsMapType():
-						writeAttrLine(attrName, structData[attrName], resource)
+						writeAttrLine(attrName, structData[attrName], "", resource)
 						delete(structData, attrName)
 					default:
 						log.Debugf("unexpected collection type %q", ty.FriendlyName())

--- a/internal/app/cf-terraforming/cmd/generate_test.go
+++ b/internal/app/cf-terraforming/cmd/generate_test.go
@@ -136,6 +136,7 @@ func TestResourceGeneration(t *testing.T) {
 		"cloudflare ruleset (no configuration)":              {identiferType: "zone", resourceType: "cloudflare_ruleset", testdataFilename: "cloudflare_ruleset_zone_no_configuration"},
 		"cloudflare ruleset (override remapping = disabled)": {identiferType: "zone", resourceType: "cloudflare_ruleset", testdataFilename: "cloudflare_ruleset_override_remapping_disabled"},
 		"cloudflare ruleset (override remapping = enabled)":  {identiferType: "zone", resourceType: "cloudflare_ruleset", testdataFilename: "cloudflare_ruleset_override_remapping_enabled"},
+		"cloudflare ruleset (rewrite to empty query string)": {identiferType: "zone", resourceType: "cloudflare_ruleset", testdataFilename: "cloudflare_ruleset_zone_rewrite_to_empty_query_parameter"},
 		"cloudflare ruleset":                                 {identiferType: "zone", resourceType: "cloudflare_ruleset", testdataFilename: "cloudflare_ruleset_zone"},
 		"cloudflare spectrum application":                    {identiferType: "zone", resourceType: "cloudflare_spectrum_application", testdataFilename: "cloudflare_spectrum_application"},
 		"cloudflare tunnel":                                  {identiferType: "account", resourceType: "cloudflare_tunnel", testdataFilename: "cloudflare_tunnel"},

--- a/internal/app/cf-terraforming/cmd/generate_test.go
+++ b/internal/app/cf-terraforming/cmd/generate_test.go
@@ -71,7 +71,7 @@ func TestGenerate_writeAttrLine(t *testing.T) {
 	for name, tc := range tests {
 		f := hclwrite.NewEmptyFile()
 		t.Run(name, func(t *testing.T) {
-			writeAttrLine(tc.key, tc.value, f.Body())
+			writeAttrLine(tc.key, tc.value, "", f.Body())
 			assert.Equal(t, tc.want, string(f.Bytes()))
 		})
 	}

--- a/internal/app/cf-terraforming/cmd/util.go
+++ b/internal/app/cf-terraforming/cmd/util.go
@@ -210,7 +210,7 @@ func processBlocks(schemaBlock *tfjson.SchemaBlock, structData map[string]interf
 				continue
 			}
 			if _, ok := schemaBlock.Attributes[block]; ok && (schemaBlock.Attributes[block].Optional || schemaBlock.Attributes[block].Required) {
-				writeAttrLine(block, structData[block], parent)
+				writeAttrLine(block, structData[block], parentBlock, parent)
 			}
 		}
 	}
@@ -218,7 +218,7 @@ func processBlocks(schemaBlock *tfjson.SchemaBlock, structData map[string]interf
 
 // writeAttrLine outputs a line of HCL configuration with a configurable depth
 // for known types.
-func writeAttrLine(key string, value interface{}, body *hclwrite.Body) {
+func writeAttrLine(key string, value interface{}, parentName string, body *hclwrite.Body) {
 	switch values := value.(type) {
 	case []map[string]interface{}:
 		var childCty []cty.Value
@@ -268,15 +268,15 @@ func writeAttrLine(key string, value interface{}, body *hclwrite.Body) {
 			}
 		}
 		if len(stringItems) > 0 {
-			writeAttrLine(key, stringItems, body)
+			writeAttrLine(key, stringItems, parentName, body)
 		}
 
 		if len(intItems) > 0 {
-			writeAttrLine(key, intItems, body)
+			writeAttrLine(key, intItems, parentName, body)
 		}
 
 		if len(interfaceItems) > 0 {
-			writeAttrLine(key, interfaceItems, body)
+			writeAttrLine(key, interfaceItems, parentName, body)
 		}
 	case []int:
 		var vals []cty.Value

--- a/internal/app/cf-terraforming/cmd/util.go
+++ b/internal/app/cf-terraforming/cmd/util.go
@@ -295,6 +295,10 @@ func writeAttrLine(key string, value interface{}, parentName string, body *hclwr
 			body.SetAttributeValue(key, cty.ListVal(vals))
 		}
 	case string:
+		if parentName == "query" && key == "value" && value == "" {
+			body.SetAttributeValue(key, cty.StringVal(""))
+		}
+
 		if value != "" {
 			body.SetAttributeValue(key, cty.StringVal(value.(string)))
 		}

--- a/testdata/cloudflare/cloudflare_ruleset_zone_http_request_late_transform.yaml
+++ b/testdata/cloudflare/cloudflare_ruleset_zone_http_request_late_transform.yaml
@@ -67,7 +67,6 @@ interactions:
                   },
                   "example-http-header-3": {
                     "operation": "set",
-                    "value": "space-header",
                     "expression": "(ip.geoip.continent eq \"pluto\")"
                   }
                 },
@@ -91,8 +90,7 @@ interactions:
                 "headers": {
                   "example-http-static-header-1": {
                     "operation": "set",
-                    "value": "my-http-header-1",
-                    "expression": "(ip.geoip.continent eq \"T1\")"
+                    "value": "my-http-header-1"
                   }
                 }
               },

--- a/testdata/cloudflare/cloudflare_ruleset_zone_rewrite_to_empty_query_parameter.yaml
+++ b/testdata/cloudflare/cloudflare_ruleset_zone_rewrite_to_empty_query_parameter.yaml
@@ -1,0 +1,89 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: https://api.cloudflare.com/client/v4/zones/0da42c8d2132a9ddaf714f9e7c920711/rulesets
+    method: GET
+  response:
+    body: |
+      {
+        "result": [
+          {
+            "id": "c0e45d27315a4fa2bf62ffa2312f935b",
+            "name": "default",
+            "description": "",
+            "kind": "zone",
+            "version": "5",
+            "last_updated": "2023-02-16T00:26:08.978517Z",
+            "phase": "http_request_transform"
+          }
+        ],
+        "success": true,
+        "errors": [],
+        "messages": []
+      }
+
+    headers:
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept-Encoding
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: https://api.cloudflare.com/client/v4/zones/0da42c8d2132a9ddaf714f9e7c920711/rulesets/c0e45d27315a4fa2bf62ffa2312f935b
+    method: GET
+  response:
+    body: |
+      {
+        "result": {
+          "id": "c0e45d27315a4fa2bf62ffa2312f935b",
+          "name": "default",
+          "description": "",
+          "kind": "zone",
+          "version": "5",
+          "rules": [
+            {
+              "id": "1fb6a3117e864d46bcda192d14a1e1dc",
+              "version": "5",
+              "action": "rewrite",
+              "expression": "true",
+              "description": "rewrite with no query string",
+              "last_updated": "2023-02-16T00:26:08.978517Z",
+              "ref": "1fb6a3117e864d46bcda192d14a1e1dc",
+              "enabled": true,
+              "action_parameters": {
+                "uri": {
+                  "query": {
+                    "value": ""
+                  }
+                }
+              }
+            }
+          ],
+          "last_updated": "2023-02-16T00:26:08.978517Z",
+          "phase": "http_request_transform"
+        },
+        "success": true,
+        "errors": [],
+        "messages": []
+      }
+    headers:
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept-Encoding
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/testdata/terraform/cloudflare_ruleset_http_request_cache_settings/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_http_request_cache_settings/test.tf
@@ -54,7 +54,10 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     description  = "test cache rule"
     enabled      = false
     expression   = "(http.host eq \"example.com\")"
+    id           = "0f24aab3002347a9a4ac01520e6893d0"
     last_updated = "2022-09-28T17:21:21.510301Z"
+    ref          = "0f24aab3002347a9a4ac01520e6893d0"
+    version      = "3"
   }
   rules {
     action = "set_cache_settings"
@@ -68,6 +71,9 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     description  = "/status/202"
     enabled      = true
     expression   = "(http.host eq \"example.com\")"
+    id           = "e5f1bd1386b4464aa8d726ba1e0d51ad"
     last_updated = "2022-09-21T16:36:00.999083Z"
+    ref          = "e5f1bd1386b4464aa8d726ba1e0d51ad"
+    version      = "2"
   }
 }

--- a/testdata/terraform/cloudflare_ruleset_zone/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone/test.tf
@@ -17,6 +17,9 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     }
     enabled      = true
     expression   = "true"
+    id           = "0789dc4343054d1e981f8c44bedc6fbd"
     last_updated = "2021-08-19T23:41:34.985519Z"
+    ref          = "0789dc4343054d1e981f8c44bedc6fbd"
+    version      = "1"
   }
 }

--- a/testdata/terraform/cloudflare_ruleset_zone_ddos_l7/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_ddos_l7/test.tf
@@ -15,6 +15,9 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     description  = "zone"
     enabled      = true
     expression   = "true"
+    id           = "c6893ad10fb344e9b8be3c0c3575adc9"
     last_updated = "2021-08-30T02:38:50.39057Z"
+    ref          = "c6893ad10fb344e9b8be3c0c3575adc9"
+    version      = "1"
   }
 }

--- a/testdata/terraform/cloudflare_ruleset_zone_http_log_custom_fields/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_http_log_custom_fields/test.tf
@@ -13,6 +13,9 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     description  = "zone"
     enabled      = true
     expression   = "true"
+    id           = "17a0d1e23a3444ccbd5e58fc7793649a"
     last_updated = "2022-07-22T12:34:45.479429Z"
+    ref          = "17a0d1e23a3444ccbd5e58fc7793649a"
+    version      = "1"
   }
 }

--- a/testdata/terraform/cloudflare_ruleset_zone_http_ratelimit/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_http_ratelimit/test.tf
@@ -8,6 +8,7 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     description  = "fwewe"
     enabled      = false
     expression   = "(http.cookie eq \"namwe=value\")"
+    id           = "549e64153ff14d2cb5a5ef88c1f5bdbc"
     last_updated = "2021-08-29T21:59:21.447624Z"
     ratelimit {
       characteristics     = ["ip.src", "cf.colo.id"]
@@ -15,5 +16,7 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
       period              = 60
       requests_per_period = 100
     }
+    ref     = "549e64153ff14d2cb5a5ef88c1f5bdbc"
+    version = "1"
   }
 }

--- a/testdata/terraform/cloudflare_ruleset_zone_http_request_firewall_custom/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_http_request_firewall_custom/test.tf
@@ -13,23 +13,32 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     description  = "test.example.com"
     enabled      = true
     expression   = "(http.host eq \"test.example.com\")"
+    id           = "88dcb30401e348ba9e1352c2598f2a4c"
     last_updated = "2022-11-24T14:24:14.756247Z"
     logging {
       enabled = true
     }
+    ref     = "88dcb30401e348ba9e1352c2598f2a4c"
+    version = "2"
   }
   rules {
     action       = "challenge"
     description  = "customRule-test"
     enabled      = true
     expression   = "(cf.bot_management.score eq 50 and cf.bot_management.static_resource)"
+    id           = "b3cc5e4cc6604f9d90a6a106df867760"
     last_updated = "2022-11-07T19:03:05.198191Z"
+    ref          = "b3cc5e4cc6604f9d90a6a106df867760"
+    version      = "29"
   }
   rules {
     action       = "log"
     description  = "AWAF ML"
     enabled      = false
     expression   = "(cf.waf.score le 20)"
+    id           = "1ecf73bdf7bd4227969a734412b13ad1"
     last_updated = "2022-12-09T16:53:19.003821Z"
+    ref          = "1ecf73bdf7bd4227969a734412b13ad1"
+    version      = "7"
   }
 }

--- a/testdata/terraform/cloudflare_ruleset_zone_http_request_late_transform/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_http_request_late_transform/test.tf
@@ -18,7 +18,6 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
         expression = "(ip.geoip.continent eq \"pluto\")"
         name       = "example-http-header-3"
         operation  = "set"
-        value      = "space-header"
       }
       uri {
         path {
@@ -38,10 +37,9 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     action = "rewrite"
     action_parameters {
       headers {
-        expression = "(ip.geoip.continent eq \"T1\")"
-        name       = "example-http-static-header-1"
-        operation  = "set"
-        value      = "my-http-header-1"
+        name      = "example-http-static-header-1"
+        operation = "set"
+        value     = "my-http-header-1"
       }
     }
     description  = "test transform set"

--- a/testdata/terraform/cloudflare_ruleset_zone_http_request_late_transform/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_http_request_late_transform/test.tf
@@ -29,7 +29,10 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     description  = "test transform"
     enabled      = true
     expression   = "(http.request.uri.path eq \"example.com\")"
+    id           = "e5b61605d6cf4ce08f729c17d42d76ef"
     last_updated = "2022-02-07T16:58:54.317608Z"
+    ref          = "e5b61605d6cf4ce08f729c17d42d76ef"
+    version      = "1"
   }
   rules {
     action = "rewrite"
@@ -44,7 +47,10 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     description  = "test transform set"
     enabled      = true
     expression   = "(http.request.uri.path eq \"example.com\")"
+    id           = "8ec764cf386940c89dd83dbab7bb4c16"
     last_updated = "2022-02-07T16:58:54.317608Z"
+    ref          = "8ec764cf386940c89dd83dbab7bb4c16"
+    version      = "1"
   }
   rules {
     action = "rewrite"
@@ -58,6 +64,9 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     description  = "test uri rewrite set"
     enabled      = false
     expression   = "(http.request.uri.path eq \"pumpkin.com\")"
+    id           = "d0f1b4fdb4234adf9c6de9b614424836"
     last_updated = "2022-05-07T16:58:54.317608Z"
+    ref          = "d0f1b4fdb4234adf9c6de9b614424836"
+    version      = "1"
   }
 }

--- a/testdata/terraform/cloudflare_ruleset_zone_http_request_sanitize/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_http_request_sanitize/test.tf
@@ -17,6 +17,9 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     }
     enabled      = true
     expression   = "true"
+    id           = "0789dc4343054d1e981f8c44bedc6fbd"
     last_updated = "2021-08-19T23:41:34.985519Z"
+    ref          = "0789dc4343054d1e981f8c44bedc6fbd"
+    version      = "1"
   }
 }

--- a/testdata/terraform/cloudflare_ruleset_zone_rewrite_to_empty_query_parameter/provider.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_rewrite_to_empty_query_parameter/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
+  }
+}

--- a/testdata/terraform/cloudflare_ruleset_zone_rewrite_to_empty_query_parameter/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_rewrite_to_empty_query_parameter/test.tf
@@ -1,0 +1,23 @@
+resource "cloudflare_ruleset" "terraform_managed_resource" {
+  kind    = "zone"
+  name    = "default"
+  phase   = "http_request_transform"
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  rules {
+    action       = "rewrite"
+    description  = "rewrite with no query string"
+    enabled      = true
+    expression   = "true"
+    id           = "1fb6a3117e864d46bcda192d14a1e1dc"
+    last_updated = "2023-02-16T00:26:08.978517Z"
+    ref          = "1fb6a3117e864d46bcda192d14a1e1dc"
+    version      = "5"
+    action_parameters {
+      uri {
+        query {
+          value = ""
+        }
+      }
+    }
+  }
+}

--- a/testdata/terraform/cloudflare_ruleset_zone_rewrite_to_empty_query_parameter/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_rewrite_to_empty_query_parameter/test.tf
@@ -4,14 +4,7 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
   phase   = "http_request_transform"
   zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
   rules {
-    action       = "rewrite"
-    description  = "rewrite with no query string"
-    enabled      = true
-    expression   = "true"
-    id           = "1fb6a3117e864d46bcda192d14a1e1dc"
-    last_updated = "2023-02-16T00:26:08.978517Z"
-    ref          = "1fb6a3117e864d46bcda192d14a1e1dc"
-    version      = "5"
+    action = "rewrite"
     action_parameters {
       uri {
         query {
@@ -19,5 +12,12 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
         }
       }
     }
+    description  = "rewrite with no query string"
+    enabled      = true
+    expression   = "true"
+    id           = "1fb6a3117e864d46bcda192d14a1e1dc"
+    last_updated = "2023-02-16T00:26:08.978517Z"
+    ref          = "1fb6a3117e864d46bcda192d14a1e1dc"
+    version      = "5"
   }
 }


### PR DESCRIPTION
This PR achieves two things. The fist, updates `writeAttrLine` to accept the parent block information and allow us to perform different behaviour based on the ancestry. The second allows customers to strip query string parameters in rewrite rules and ensures `cf-terraforming` knows it is a special case for empty strings.