### PR TITLE
bugfix: cf-tf adds extra space before IDs in ruleset rules block

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -857,7 +857,7 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 											for _, val := range value.([]interface{}) {
 												rulesList = append(rulesList, val.(string))
 											}
-											actionParams.(map[string]interface{})[rule].(map[string]interface{})[key] = strings.Join(rulesList, ", ")
+											actionParams.(map[string]interface{})[rule].(map[string]interface{})[key] = strings.Join(rulesList, ",")
 										}
 									}
 								}

--- a/testdata/cloudflare/cloudflare_ruleset_zone_http_request_firewall_managed.yaml
+++ b/testdata/cloudflare/cloudflare_ruleset_zone_http_request_firewall_managed.yaml
@@ -179,6 +179,95 @@ interactions:
                 "description": "zone",
                 "last_updated": "2021-09-03T06:42:41.341405Z",
                 "enabled": false
+              },
+              {
+                "id": "d189267a8dc943769d0000c3dcb400eb",
+                "version": "1",
+                "action": "skip",
+                "expression": "(http.request.method eq \"POST\" and http.request.uri.path eq \"/api/v1/identity\")",
+                "description": "Bypass managed OWSAP SQL Injection rules for /api/v1/identity",
+                "last_updated": "2023-05-12T08:23:03.177093Z",
+                "ref": "d189267a8dc943769d0000c3dcb400eb",
+                "enabled": true,
+                "logging": {
+                  "enabled": true
+                },
+                "action_parameters": {
+                  "rules": {
+                    "4814384a9e5d4991b9815dcfc25d2f1f": [
+                      "37da7855d2f94f69865365d894a556a4",
+                      "6afe6795ee6a48d6a1dfe59255395a78",
+                      "5a6f5a57cde8428ab0668ce17cdec0c8",
+                      "5e4903d6afa841c9b88b96203297003f",
+                      "2380cd409b604c2a9273042f3eb29c4e",
+                      "f5aebedc99a14c8d9e8cfa2ce5f94216",
+                      "edf8c37cc81747d382690b3c77e82ce4",
+                      "1129dfb383bb42e48466488cf3b37cb1"
+                    ]
+                  }
+                }
+              }
+            ],
+            "last_updated": "2021-09-03T06:42:41.341405Z",
+            "phase": "http_request_firewall_managed"
+          },
+          "success": true,
+          "errors": [],
+          "messages": []
+        }
+      headers:
+        Content-Type:
+          - application/json
+        Vary:
+          - Accept-Encoding
+      status: 200 OK
+      code: 200
+      duration: ""
+  - request:
+      body: ""
+      form: {}
+      headers:
+        Content-Type:
+          - application/json
+      url: https://api.cloudflare.com/client/v4/zones/0da42c8d2132a9ddaf714f9e7c920711/rulesets/4814384a9e5d4991b9815dcfc25d2f1f
+      method: GET
+    response:
+      body: |
+        {
+          "result": {
+            "id": "4814384a9e5d4991b9815dcfc25d2f1f",
+            "name": "zone",
+            "description": "",
+            "source": "firewall_managed",
+            "kind": "zone",
+            "version": "2",
+            "rules": [
+              {
+                "id": "d189267a8dc943769d0000c3dcb400eb",
+                "version": "1",
+                "action": "skip",
+                "expression": "(http.request.method eq \"POST\" and http.request.uri.path eq \"/api/v1/identity\")",
+                "description": "Bypass managed OWSAP SQL Injection rules for /api/v1/identity",
+                "last_updated": "2023-05-12T08:23:03.177093Z",
+                "ref": "d189267a8dc943769d0000c3dcb400eb",
+                "enabled": true,
+                "logging": {
+                  "enabled": true
+                },
+                "action_parameters": {
+                  "rules": {
+                    "4814384a9e5d4991b9815dcfc25d2f1f": [
+                      "37da7855d2f94f69865365d894a556a4",
+                      "6afe6795ee6a48d6a1dfe59255395a78",
+                      "5a6f5a57cde8428ab0668ce17cdec0c8",
+                      "5e4903d6afa841c9b88b96203297003f",
+                      "2380cd409b604c2a9273042f3eb29c4e",
+                      "f5aebedc99a14c8d9e8cfa2ce5f94216",
+                      "edf8c37cc81747d382690b3c77e82ce4",
+                      "1129dfb383bb42e48466488cf3b37cb1"
+                    ]
+                  }
+                }
               }
             ],
             "last_updated": "2021-09-03T06:42:41.341405Z",

--- a/testdata/terraform/cloudflare_ruleset_zone_http_request_firewall_managed/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_http_request_firewall_managed/test.tf
@@ -76,4 +76,22 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     expression   = "(http.cookie eq \"jb_testing=true\")"
     last_updated = "2021-09-03T06:42:41.341405Z"
   }
+  rules {
+    action = "skip"
+    action_parameters {
+      rules = {
+        "4814384a9e5d4991b9815dcfc25d2f1f" = "37da7855d2f94f69865365d894a556a4,6afe6795ee6a48d6a1dfe59255395a78,5a6f5a57cde8428ab0668ce17cdec0c8,5e4903d6afa841c9b88b96203297003f,2380cd409b604c2a9273042f3eb29c4e,f5aebedc99a14c8d9e8cfa2ce5f94216,edf8c37cc81747d382690b3c77e82ce4,1129dfb383bb42e48466488cf3b37cb1"
+      }
+    }
+    description  = "Bypass managed OWSAP SQL Injection rules for /api/v1/identity"
+    enabled      = true
+    expression   = "(http.request.method eq \"POST\" and http.request.uri.path eq \"/api/v1/identity\")"
+    id           = "d189267a8dc943769d0000c3dcb400eb"
+    last_updated = "2023-05-12T08:23:03.177093Z"
+    logging {
+      enabled = true
+    }
+    ref     = "d189267a8dc943769d0000c3dcb400eb"
+    version = "1"
+  }
 }


### PR DESCRIPTION
I was checking a customer's tf config why it was failing and noticed this:
```
...
action = "skip"
  action_parameters {
    rules = {
      "4814384a9e5d4991b9815dcfc25d2f1f" = "37da7855d2f94f69865365d894a556a4, 6afe6795ee6a48d6a1dfe59255395a78, 5a6f5a57cde8428ab0668ce17cdec0c8, 5e4903d6afa841c9b88b96203297003f, 2380cd409b604c2a9273042f3eb29c4e, f5aebedc99a14c8d9e8cfa2ce5f94216, edf8c37cc81747d382690b3c77e82ce4, 1129dfb383bb42e48466488cf3b37cb1"
    }
  }
...
```
It's not much, but if you try to apply it, you can see the JSON that is sent to rulesets:
```
...
"action": "skip",
"action_parameters": {
    "rules": {
        "4814384a9e5d4991b9815dcfc25d2f1f": [
            "37da7855d2f94f69865365d894a556a4",
            " 6afe6795ee6a48d6a1dfe59255395a78",
            " 5a6f5a57cde8428ab0668ce17cdec0c8",
            " 5e4903d6afa841c9b88b96203297003f",
            " 2380cd409b604c2a9273042f3eb29c4e",
            " f5aebedc99a14c8d9e8cfa2ce5f94216",
            " edf8c37cc81747d382690b3c77e82ce4",
            " 1129dfb383bb42e48466488cf3b37cb1"
        ]
    }
},
...
```
It could be that the old way of generating the TF trimmed the whitespace for us and in the new way, it doesn't do that anymore.

Anyway, this PR is to fix this bug.



