### PR TITLE
Add support for turnstile_widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Any resources not listed are currently not supported.
 | [cloudflare_ruleset](https://www.terraform.io/docs/providers/cloudflare/r/ruleset)                                                               | Account or Zone | ✅                 | ✅               |
 | [cloudflare_spectrum_application](https://www.terraform.io/docs/providers/cloudflare/r/spectrum_application)                                     | Zone            | ✅                 | ✅               |
 | [cloudflare_tunnel](https://www.terraform.io/docs/providers/cloudflare/r/tunnel)                                                                 | Account         | ✅                 | ✅               |
+| [cloudflare_turnstile_widget](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/turnstile_widget)              | Account         | ✅                 | ✅               |
 | [cloudflare_url_normalization_settings](https://www.terraform.io/docs/providers/cloudflare/r/url_normalization_settings)                         | Zone            | ✅                 | ❌               |
 | [cloudflare_waf_group](https://www.terraform.io/docs/providers/cloudflare/r/waf_group)                                                           | Zone            | ❌                 | ❌               |
 | [cloudflare_waf_override](https://www.terraform.io/docs/providers/cloudflare/r/waf_override)                                                     | Zone            | ✅                 | ✅               |

--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -932,6 +932,22 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 
 				jsonStructData[i].(map[string]interface{})["connections"] = nil
 			}
+		case "cloudflare_turnstile_widget":
+			jsonPayload, _, err := api.ListTurnstileWidgets(context.Background(), cloudflare.AccountIdentifier(accountID), cloudflare.ListTurnstileWidgetParams{})
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			resourceCount = len(jsonPayload)
+			m, _ := json.Marshal(jsonPayload)
+			err = json.Unmarshal(m, &jsonStructData)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			for i := 0; i < resourceCount; i++ {
+				jsonStructData[i].(map[string]interface{})["id"] = jsonStructData[i].(map[string]interface{})["sitekey"]
+			}
 		case "cloudflare_url_normalization_settings":
 			jsonPayload, err := api.URLNormalizationSettings(context.Background(), &cloudflare.ResourceContainer{Identifier: zoneID, Level: cloudflare.ZoneRouteLevel})
 			if err != nil {

--- a/internal/app/cf-terraforming/cmd/generate_test.go
+++ b/internal/app/cf-terraforming/cmd/generate_test.go
@@ -140,6 +140,7 @@ func TestResourceGeneration(t *testing.T) {
 		"cloudflare ruleset":                                 {identiferType: "zone", resourceType: "cloudflare_ruleset", testdataFilename: "cloudflare_ruleset_zone"},
 		"cloudflare spectrum application":                    {identiferType: "zone", resourceType: "cloudflare_spectrum_application", testdataFilename: "cloudflare_spectrum_application"},
 		"cloudflare tunnel":                                  {identiferType: "account", resourceType: "cloudflare_tunnel", testdataFilename: "cloudflare_tunnel"},
+		"cloudflare turnstile_widget":                        {identiferType: "account", resourceType: "cloudflare_turnstile_widget", testdataFilename: "cloudflare_turnstile_widget"},
 		"cloudflare url normalization settings":              {identiferType: "zone", resourceType: "cloudflare_url_normalization_settings", testdataFilename: "cloudflare_url_normalization_settings"},
 		"cloudflare user agent blocking rule":                {identiferType: "zone", resourceType: "cloudflare_user_agent_blocking_rule", testdataFilename: "cloudflare_user_agent_blocking_rule"},
 		"cloudflare waiting room":                            {identiferType: "zone", resourceType: "cloudflare_waiting_room", testdataFilename: "cloudflare_waiting_room"},

--- a/internal/app/cf-terraforming/cmd/import.go
+++ b/internal/app/cf-terraforming/cmd/import.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
-	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/cloudflare/cloudflare-go"
 	"github.com/spf13/cobra"
-
-	"fmt"
 )
 
 // resourceImportStringFormats contains a mapping of the resource type to the
@@ -38,6 +37,7 @@ var resourceImportStringFormats = map[string]string{
 	"cloudflare_ruleset":               ":identifier_type/:identifier_value/:id",
 	"cloudflare_spectrum_application":  ":zone_id/:id",
 	"cloudflare_tunnel":                ":account_id/:id",
+	"cloudflare_turnstile_widget":      ":account_id/:id",
 	"cloudflare_waf_override":          ":zone_id/:id",
 	"cloudflare_waiting_room":          ":zone_id/:id",
 	"cloudflare_worker_route":          ":zone_id/:id",
@@ -360,6 +360,20 @@ func runImport() func(cmd *cobra.Command, args []string) {
 			err = json.Unmarshal(m, &jsonStructData)
 			if err != nil {
 				log.Fatal(err)
+			}
+		case "cloudflare_turnstile_widget":
+			jsonPayload, _, err := api.ListTurnstileWidgets(context.Background(), cloudflare.AccountIdentifier(accountID), cloudflare.ListTurnstileWidgetParams{})
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			m, _ := json.Marshal(jsonPayload)
+			err = json.Unmarshal(m, &jsonStructData)
+			if err != nil {
+				log.Fatal(err)
+			}
+			for i := 0; i < len(jsonStructData); i++ {
+				jsonStructData[i].(map[string]interface{})["id"] = jsonStructData[i].(map[string]interface{})["sitekey"]
 			}
 		case "cloudflare_waf_override":
 			jsonPayload, err := api.ListWAFOverrides(context.Background(), zoneID)

--- a/testdata/cloudflare/cloudflare_turnstile_widget.yaml
+++ b/testdata/cloudflare/cloudflare_turnstile_widget.yaml
@@ -1,0 +1,22 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: https://api.cloudflare.com/client/v4/accounts/f037e56e89293a057740de681ac9abbe/challenges/widgets?page=1&per_page=25
+    method: GET
+  response:
+    body: |
+      {"result":[{"sitekey":"0x4AAAAAAAEg5sP3rwf91fe8","modified_on":"2023-05-08T11:49:41.862676Z","created_on":"2023-05-08T11:49:41.862676Z","mode":"managed","domains":["example.com"],"name":"test site","bot_fight_mode":false,"region":"world","offlabel":false},{"sitekey":"0x4AAAAAAAE0gwg0H1StXlOx","modified_on":"2023-05-17T02:08:18.399564Z","created_on":"2023-05-17T02:08:18.399564Z","mode":"managed","domains":["example.org"],"name":"My Terraform-managed widget","bot_fight_mode":false,"region":"world","offlabel":false},{"sitekey":"0x4AAAAAAAE2z4LbxEka5UBh","modified_on":"2023-05-17T19:11:26.151063Z","created_on":"2023-05-17T19:11:26.151063Z","mode":"managed","domains":["example.net"],"name":"My website","bot_fight_mode":false,"region":"world","offlabel":false}],"success":true,"errors":[],"messages":[],"result_info":{"page":1,"per_page":25,"count":3,"total_count":3,"total_pages":1}}
+    headers:
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept-Encoding
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/testdata/terraform/cloudflare_turnstile_widget/provider.tf
+++ b/testdata/terraform/cloudflare_turnstile_widget/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
+  }
+}

--- a/testdata/terraform/cloudflare_turnstile_widget/test.tf
+++ b/testdata/terraform/cloudflare_turnstile_widget/test.tf
@@ -1,0 +1,23 @@
+resource "cloudflare_turnstile_widget" "terraform_managed_resource" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  domains    = ["example.com"]
+  mode       = "managed"
+  name       = "test site"
+  region     = "world"
+}
+
+resource "cloudflare_turnstile_widget" "terraform_managed_resource" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  domains    = ["example.org"]
+  mode       = "managed"
+  name       = "My Terraform-managed widget"
+  region     = "world"
+}
+
+resource "cloudflare_turnstile_widget" "terraform_managed_resource" {
+  account_id = "f037e56e89293a057740de681ac9abbe"
+  domains    = ["example.net"]
+  mode       = "managed"
+  name       = "My website"
+  region     = "world"
+}


### PR DESCRIPTION
- Supports pagination
- The API doesn't return an 'id' field, so we add a helper to get the resource ID. This also helps deduplicate code between generate and import

Tested with `cloudflare/terraform-provider-cloudflare@master` + `cloudflare-go@master`:

```bash
~/code/github/punkeel/tfcf ❯ /Users/maxime/Code/github/punkeel/cf-terraforming/cf-terraforming generate --resource-type cloudflare_turnstile_widget --account 6aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa9

resource "cloudflare_turnstile_widget" "terraform_managed_resource_0x4AAAAAAAEg5sP3rwf91fe8" {
  account_id = "6aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa9"
  domains    = ["ungeek.fr"]
  mode       = "managed"
  name       = "test site"
  region     = "world"
}

resource "cloudflare_turnstile_widget" "terraform_managed_resource_0x4AAAAAAAE0gwg0H1StXlOx" {
  account_id = "6aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa9"
  domains    = ["example.com"]
  mode       = "managed"
  name       = "My Terraform-managed widget"
  region     = "world"
}

resource "cloudflare_turnstile_widget" "terraform_managed_resource_0x4AAAAAAAE2z4LbxEka5UBh" {
  account_id = "6aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa9"
  domains    = ["guerreiro.me"]
  mode       = "managed"
  name       = "My website"
  region     = "world"
}

~/code/github/punkeel/tfcf ❯ /Users/maxime/Code/github/punkeel/cf-terraforming/cf-terraforming import --resource-type cloudflare_turnstile_widget --account 6aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa9

terraform import cloudflare_turnstile_widget.terraform_managed_resource_0x4AAAAAAAEg5sP3rwf91fe8 6aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa9/0x4AAAAAAAEg5sP3rwf91fe8
terraform import cloudflare_turnstile_widget.terraform_managed_resource_0x4AAAAAAAE0gwg0H1StXlOx 6aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa9/0x4AAAAAAAE0gwg0H1StXlOx
terraform import cloudflare_turnstile_widget.terraform_managed_resource_0x4AAAAAAAE2z4LbxEka5UBh 6aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa9/0x4AAAAAAAE2z4LbxEka5UBh
```