### PR TITLE
don't return custom pages without urls

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -412,10 +412,18 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 				}
 			}
 
+			var newJsonStructData []interface{}
 			// remap ID to the "type" field
 			for i := 0; i < resourceCount; i++ {
 				jsonStructData[i].(map[string]interface{})["type"] = jsonStructData[i].(map[string]interface{})["id"]
+				// we only want repsonses that have 'url'
+				if jsonStructData[i].(map[string]interface{})["url"] != nil {
+					newJsonStructData = append(newJsonStructData, jsonStructData[i])
+				}
 			}
+			jsonStructData = newJsonStructData
+			resourceCount = len(jsonStructData)
+
 		case "cloudflare_custom_hostname_fallback_origin":
 			var jsonPayload []cloudflare.CustomHostnameFallbackOrigin
 			apiCall, err := api.CustomHostnameFallbackOrigin(context.Background(), zoneID)

--- a/testdata/cloudflare/cloudflare_custom_pages_account.yaml
+++ b/testdata/cloudflare/cloudflare_custom_pages_account.yaml
@@ -27,6 +27,18 @@ interactions:
             ],
             "preview_target": "preview:target",
             "description": "example"
+          },
+          {
+            "id": "basic_challenge",
+            "created_on": "2014-01-01T05:20:00.12345Z",
+            "modified_on": "2014-01-01T05:20:00.12345Z",
+            "url": null,
+            "state": "customized",
+            "required_tokens": [
+              "::CAPTCHA_BOX::"
+            ],
+            "preview_target": "preview:target",
+            "description": "example"
           }
         ]
       }

--- a/testdata/cloudflare/cloudflare_custom_pages_zone.yaml
+++ b/testdata/cloudflare/cloudflare_custom_pages_zone.yaml
@@ -27,6 +27,18 @@ interactions:
             ],
             "preview_target": "preview:target",
             "description": "example"
+          },
+          {
+            "id": "basic_challenge",
+            "created_on": "2014-01-01T05:20:00.12345Z",
+            "modified_on": "2014-01-01T05:20:00.12345Z",
+            "url": null,
+            "state": "customized",
+            "required_tokens": [
+              "::CAPTCHA_BOX::"
+            ],
+            "preview_target": "preview:target",
+            "description": "example"
           }
         ]
       }


### PR DESCRIPTION
After custom pages moved teams, they started turning the entire payload, even if that custom page doesn't have a url.

The expectation is that cf-terraform would not return a resource if the url doesn't exist for a custom page, this change restores that expectation. 

This also fixes #543 