### PR TITLE
add zone id for tiered cache resource

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -1099,6 +1099,7 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 				log.Fatal(err)
 			}
 
+			jsonStructData[0].(map[string]interface{})["id"] = zoneID
 			jsonStructData[0].(map[string]interface{})["cache_type"] = tieredCache.Type.String()
 		default:
 			fmt.Fprintf(cmd.OutOrStdout(), "%q is not yet supported for automatic generation", resourceType)


### PR DESCRIPTION
I was getting the following error when I tried generating `tiered_cache` resource:
```
*main.TerraformError: terraform has failed: panic: interface conversion: interface {} is nil, not string
 
goroutine 1 [running]:
github.com/cloudflare/cf-terraforming/internal/app/cf-terraforming/cmd.generateResources.func1(0xf3fd20?, \{0xaa57b2?, 0xa?, 0xa?})
/kamino/cf-terraforming/internal/app/cf-terraforming/cmd/generate.go:1127 +0x6034
github.com/spf13/cobra.(*Command).execute(0xf3fd20, \{0xc0002a3ae0, 0xa, 0xa})
/root/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:944 +0x847
github.com/spf13/cobra.(*Command).ExecuteC(0xf3fa40)
/root/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
/root/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
github.com/cloudflare/cf-terraforming/internal/app/cf-terraforming/cmd.Execute()
/kamino/cf-terraforming/internal/app/cf-terraforming/cmd/root.go:30 +0x25
main.main()
/kamino/cf-terraforming/cmd/cf-terraforming/main.go:8 +0x17
```

The reason of the failure is the generation was missing setting zone ID as ID on the resource.