### PR TITLE
generate/load_balancer: correctly remap `country_pools`, `region_pools` and `pop_pools`

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -531,7 +531,35 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 			for i := 0; i < resourceCount; i++ {
 				jsonStructData[i].(map[string]interface{})["default_pool_ids"] = jsonStructData[i].(map[string]interface{})["default_pools"]
 				jsonStructData[i].(map[string]interface{})["fallback_pool_id"] = jsonStructData[i].(map[string]interface{})["fallback_pool"]
+
+				if jsonStructData[i].(map[string]interface{})["country_pools"] != nil {
+					original := jsonStructData[i].(map[string]interface{})["country_pools"]
+					jsonStructData[i].(map[string]interface{})["country_pools"] = []interface{}{}
+
+					for country, popIDs := range original.(map[string]interface{}) {
+						jsonStructData[i].(map[string]interface{})["country_pools"] = append(jsonStructData[i].(map[string]interface{})["country_pools"].([]interface{}), map[string]interface{}{"country": country, "pool_ids": popIDs})
+					}
+				}
+
+				if jsonStructData[i].(map[string]interface{})["region_pools"] != nil {
+					original := jsonStructData[i].(map[string]interface{})["region_pools"]
+					jsonStructData[i].(map[string]interface{})["region_pools"] = []interface{}{}
+
+					for region, popIDs := range original.(map[string]interface{}) {
+						jsonStructData[i].(map[string]interface{})["region_pools"] = append(jsonStructData[i].(map[string]interface{})["region_pools"].([]interface{}), map[string]interface{}{"region": region, "pool_ids": popIDs})
+					}
+				}
+
+				if jsonStructData[i].(map[string]interface{})["pop_pools"] != nil {
+					original := jsonStructData[i].(map[string]interface{})["pop_pools"]
+					jsonStructData[i].(map[string]interface{})["pop_pools"] = []interface{}{}
+
+					for pop, popIDs := range original.(map[string]interface{}) {
+						jsonStructData[i].(map[string]interface{})["pop_pools"] = append(jsonStructData[i].(map[string]interface{})["pop_pools"].([]interface{}), map[string]interface{}{"pop": pop, "pool_ids": popIDs})
+					}
+				}
 			}
+
 		case "cloudflare_load_balancer_pool":
 			jsonPayload, err := api.ListLoadBalancerPools(context.Background(), cloudflare.AccountIdentifier(accountID), cloudflare.ListLoadBalancerPoolParams{})
 			if err != nil {

--- a/testdata/cloudflare/cloudflare_load_balancer.yaml
+++ b/testdata/cloudflare/cloudflare_load_balancer.yaml
@@ -32,12 +32,12 @@ interactions:
               "00920f38ce07c2e2f4df50b1f61d4194"
             ],
             "region_pools": {
+              "ENAM": [
+                "00920f38ce07c2e2f4df50b1f61d4194"
+              ],
               "WNAM": [
                 "de90f38ced07c2e2f4df50b1f61d4194",
                 "9290f38c5d07c2e2f4df57b1f61d4196"
-              ],
-              "ENAM": [
-                "00920f38ce07c2e2f4df50b1f61d4194"
               ]
             },
             "pop_pools": {
@@ -51,6 +51,19 @@ interactions:
               ],
               "SJC": [
                 "00920f38ce07c2e2f4df50b1f61d4194"
+              ]
+            },
+            "country_pools": {
+              "AU": [
+                "de90f38ced07c2e2f4df50b1f61d4194",
+                "9290f38c5d07c2e2f4df57b1f61d4196"
+              ],
+              "ME": [
+                "00920f38ce07c2e2f4df50b1f61d4194"
+              ],
+              "US": [
+                "abd90f38ced07c2e2f4df50b1f61d4194",
+                "f9138c5d07c2e2f4df57b1f61d4196"
               ]
             },
             "steering_policy": "dynamic_latency",

--- a/testdata/terraform/cloudflare_load_balancer/test.tf
+++ b/testdata/terraform/cloudflare_load_balancer/test.tf
@@ -10,6 +10,38 @@ resource "cloudflare_load_balancer" "terraform_managed_resource" {
   steering_policy      = "dynamic_latency"
   ttl                  = 30
   zone_id              = "0da42c8d2132a9ddaf714f9e7c920711"
+  country_pools {
+    country  = "AU"
+    pool_ids = ["de90f38ced07c2e2f4df50b1f61d4194", "9290f38c5d07c2e2f4df57b1f61d4196"]
+  }
+  country_pools {
+    country  = "ME"
+    pool_ids = ["00920f38ce07c2e2f4df50b1f61d4194"]
+  }
+  country_pools {
+    country  = "US"
+    pool_ids = ["abd90f38ced07c2e2f4df50b1f61d4194", "f9138c5d07c2e2f4df57b1f61d4196"]
+  }
+  pop_pools {
+    pool_ids = ["de90f38ced07c2e2f4df50b1f61d4194", "9290f38c5d07c2e2f4df57b1f61d4196"]
+    pop      = "LAX"
+  }
+  pop_pools {
+    pool_ids = ["abd90f38ced07c2e2f4df50b1f61d4194", "f9138c5d07c2e2f4df57b1f61d4196"]
+    pop      = "LHR"
+  }
+  pop_pools {
+    pool_ids = ["00920f38ce07c2e2f4df50b1f61d4194"]
+    pop      = "SJC"
+  }
+  region_pools {
+    pool_ids = ["00920f38ce07c2e2f4df50b1f61d4194"]
+    region   = "ENAM"
+  }
+  region_pools {
+    pool_ids = ["de90f38ced07c2e2f4df50b1f61d4194", "9290f38c5d07c2e2f4df57b1f61d4196"]
+    region   = "WNAM"
+  }
   session_affinity_attributes {
     drain_duration = 100
     samesite       = "Auto"


### PR DESCRIPTION
Updates the `cloudflare_load_balancer` generation to remap the `country_pools`, `region_pools` and `pop_pools` to the nested block instead of the object/map field.

This was a bit of tricky one to track down because the original response from the API _has_ the correct schema attributes but the kicker is that they are not a supported type (for good reasons!).