### PR TITLE
Sort items before write

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -788,6 +788,10 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 					}
 				}
 
+				sort.Slice(jsonPayload, func(i, j int) bool {
+					return jsonPayload[i].Phase < jsonPayload[j].Phase
+				})
+
 				resourceCount = len(jsonPayload)
 				m, _ := json.Marshal(jsonPayload)
 				err = json.Unmarshal(m, &jsonStructData)


### PR DESCRIPTION
While working through some issues with Version Compare, we noticed that Rulesets doesn't return phases in a specific order. 

This PR will sort Rulesets by phases.