### PR TITLE
generate: don't output default ruleset `ref` values

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -791,6 +791,14 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 				rules := jsonStructData[i].(map[string]interface{})["rules"]
 				if rules != nil {
 					for ruleCounter := range rules.([]interface{}) {
+						// should the `ref` be the default `id`, don't output it
+						// as we don't need to track a computed default.
+						id := rules.([]interface{})[ruleCounter].(map[string]interface{})["id"]
+						ref := rules.([]interface{})[ruleCounter].(map[string]interface{})["ref"]
+						if id == ref {
+							rules.([]interface{})[ruleCounter].(map[string]interface{})["ref"] = nil
+						}
+
 						actionParams := rules.([]interface{})[ruleCounter].(map[string]interface{})["action_parameters"]
 						if actionParams != nil {
 							// check for log custom fields that need to be transformed

--- a/testdata/terraform/cloudflare_ruleset_http_request_cache_settings/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_http_request_cache_settings/test.tf
@@ -54,7 +54,6 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     description = "test cache rule"
     enabled     = false
     expression  = "(http.host eq \"example.com\")"
-    ref         = "0f24aab3002347a9a4ac01520e6893d0"
   }
   rules {
     action = "set_cache_settings"
@@ -68,6 +67,5 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     description = "/status/202"
     enabled     = true
     expression  = "(http.host eq \"example.com\")"
-    ref         = "e5f1bd1386b4464aa8d726ba1e0d51ad"
   }
 }

--- a/testdata/terraform/cloudflare_ruleset_zone/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone/test.tf
@@ -17,6 +17,5 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     }
     enabled    = true
     expression = "true"
-    ref        = "0789dc4343054d1e981f8c44bedc6fbd"
   }
 }

--- a/testdata/terraform/cloudflare_ruleset_zone_ddos_l7/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_ddos_l7/test.tf
@@ -15,6 +15,5 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     description = "zone"
     enabled     = true
     expression  = "true"
-    ref         = "c6893ad10fb344e9b8be3c0c3575adc9"
   }
 }

--- a/testdata/terraform/cloudflare_ruleset_zone_http_log_custom_fields/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_http_log_custom_fields/test.tf
@@ -13,6 +13,5 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     description = "zone"
     enabled     = true
     expression  = "true"
-    ref         = "17a0d1e23a3444ccbd5e58fc7793649a"
   }
 }

--- a/testdata/terraform/cloudflare_ruleset_zone_http_ratelimit/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_http_ratelimit/test.tf
@@ -14,6 +14,5 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
       period              = 60
       requests_per_period = 100
     }
-    ref = "549e64153ff14d2cb5a5ef88c1f5bdbc"
   }
 }

--- a/testdata/terraform/cloudflare_ruleset_zone_http_request_firewall_custom/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_http_request_firewall_custom/test.tf
@@ -16,20 +16,17 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     logging {
       enabled = true
     }
-    ref = "88dcb30401e348ba9e1352c2598f2a4c"
   }
   rules {
     action      = "challenge"
     description = "customRule-test"
     enabled     = true
     expression  = "(cf.bot_management.score eq 50 and cf.bot_management.static_resource)"
-    ref         = "b3cc5e4cc6604f9d90a6a106df867760"
   }
   rules {
     action      = "log"
     description = "AWAF ML"
     enabled     = false
     expression  = "(cf.waf.score le 20)"
-    ref         = "1ecf73bdf7bd4227969a734412b13ad1"
   }
 }

--- a/testdata/terraform/cloudflare_ruleset_zone_http_request_firewall_managed/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_http_request_firewall_managed/test.tf
@@ -88,6 +88,5 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     logging {
       enabled = true
     }
-    ref = "d189267a8dc943769d0000c3dcb400eb"
   }
 }

--- a/testdata/terraform/cloudflare_ruleset_zone_http_request_late_transform/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_http_request_late_transform/test.tf
@@ -28,7 +28,6 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     description = "test transform"
     enabled     = true
     expression  = "(http.request.uri.path eq \"example.com\")"
-    ref         = "e5b61605d6cf4ce08f729c17d42d76ef"
   }
   rules {
     action = "rewrite"
@@ -42,7 +41,6 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     description = "test transform set"
     enabled     = true
     expression  = "(http.request.uri.path eq \"example.com\")"
-    ref         = "8ec764cf386940c89dd83dbab7bb4c16"
   }
   rules {
     action = "rewrite"
@@ -56,6 +54,5 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     description = "test uri rewrite set"
     enabled     = false
     expression  = "(http.request.uri.path eq \"pumpkin.com\")"
-    ref         = "d0f1b4fdb4234adf9c6de9b614424836"
   }
 }

--- a/testdata/terraform/cloudflare_ruleset_zone_http_request_sanitize/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_http_request_sanitize/test.tf
@@ -17,6 +17,5 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     }
     enabled    = true
     expression = "true"
-    ref        = "0789dc4343054d1e981f8c44bedc6fbd"
   }
 }

--- a/testdata/terraform/cloudflare_ruleset_zone_rewrite_to_empty_query_parameter/test.tf
+++ b/testdata/terraform/cloudflare_ruleset_zone_rewrite_to_empty_query_parameter/test.tf
@@ -15,6 +15,5 @@ resource "cloudflare_ruleset" "terraform_managed_resource" {
     description = "rewrite with no query string"
     enabled     = true
     expression  = "true"
-    ref         = "1fb6a3117e864d46bcda192d14a1e1dc"
   }
 }


### PR DESCRIPTION
Updates the output generation to skip outputting the `ref` value in the case where it is the computed default (same as `id`).

This aligns the output with the expectation in the [schema][1] where the `ref` maybe computed.

[1]: https://github.com/cloudflare/terraform-provider-cloudflare/commit/5b01f8dd852077ec7d977cb916a6522df747e6e9