### PR TITLE
fix test data for cloudflare_bot_management

### DIFF
--- a/testdata/cloudflare/cloudflare_bot_management.yaml
+++ b/testdata/cloudflare/cloudflare_bot_management.yaml
@@ -17,16 +17,14 @@ interactions:
         "success": true,
         "errors": [],
         "messages": [],
-        "result": [
-          {
-            "enable_js": true,
-            "sbfm_definitely_automated": "block",
-            "sbfm_likely_automated": "managed_challenge",
-            "sbfm_verified_bots": "allow",
-            "sbfm_static_resource_protection": false,
-            "optimize_wordpress": true
-          }
-        ]
+        "result": {
+          "enable_js": true,
+          "sbfm_definitely_automated": "block",
+          "sbfm_likely_automated": "managed_challenge",
+          "sbfm_verified_bots": "allow",
+          "sbfm_static_resource_protection": false,
+          "optimize_wordpress": true
+        }
       }
     headers:
       Content-Type:


### PR DESCRIPTION
The result payload is not supposed to be nested in an array. That was a mistake when I copied over from a different file. Looks like we didn't run the tests before merging to master.