### PR TITLE
import: add support for `import` blocks in Terraform 1.5+

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,16 +135,30 @@ If you use another OS, you will need to download the release directly from
 
 ## Importing with Terraform state
 
-`cf-terraforming` will output the `terraform import` compatible commands for you
-when you invoke the `import` command. This command assumes you have already ran
-`cf-terraforming generate ...` to output your resources.
+`cf-terraforming` has the ability to generate the configuration for you to import
+existing resources.
 
-In the future we aim to automate this however for now, it is a manual step to
-allow flexibility in directory structure.
+Depending on your version of Terraform, you can generate the `import` block
+(Terraform 1.5+) using the `--modern-import-block` flag or the `terraform import`
+compatible CLI output (all versions).
+
+This command assumes you have already ran `cf-terraforming generate ...` to
+output your resources.
 
 ```
+# All versions of Terraform
 $ cf-terraforming import \
   --resource-type "cloudflare_record" \
+  --email $CLOUDFLARE_EMAIL \
+  --key $CLOUDFLARE_API_KEY \
+  --zone $CLOUDFLARE_ZONE_ID
+```
+
+```
+# Terraform 1.5+ only
+$ cf-terraforming import \
+  --resource-type "cloudflare_record" \
+  --modern-import-block \
   --email $CLOUDFLARE_EMAIL \
   --key $CLOUDFLARE_API_KEY \
   --zone $CLOUDFLARE_ZONE_ID
@@ -157,7 +171,7 @@ Any resources not listed are currently not supported.
 | Resource                                                                                                                                         | Resource Scope  | Generate Supported | Import Supported |
 | ------------------------------------------------------------------------------------------------------------------------------------------------ | --------------- | ------------------ | ---------------- |
 | [cloudflare_access_application](https://www.terraform.io/docs/providers/cloudflare/r/access_application)                                         | Account         | ✅                 | ❌               |
-| [cloudflare_access_group](https://www.terraform.io/docs/providers/cloudflare/r/access_group)                                                     | Account         | ✅                 | ✅                |
+| [cloudflare_access_group](https://www.terraform.io/docs/providers/cloudflare/r/access_group)                                                     | Account         | ✅                 | ✅               |
 | [cloudflare_access_identity_provider](https://www.terraform.io/docs/providers/cloudflare/r/access_identity_provider)                             | Account         | ✅                 | ❌               |
 | [cloudflare_access_mutual_tls_certificate](https://www.terraform.io/docs/providers/cloudflare/r/access_mutual_tls_certificate)                   | Account         | ✅                 | ❌               |
 | [cloudflare_access_policy](https://www.terraform.io/docs/providers/cloudflare/r/access_policy)                                                   | Account         | ❌                 | ❌               |

--- a/internal/app/cf-terraforming/cmd/root.go
+++ b/internal/app/cf-terraforming/cmd/root.go
@@ -10,7 +10,7 @@ import (
 
 var log = logrus.New()
 var cfgFile, zoneID, hostname, apiEmail, apiKey, apiToken, accountID, terraformInstallPath, terraformBinaryPath string
-var verbose bool
+var verbose, useModernImportBlock bool
 var api *cloudflare.API
 var terraformImportCmdPrefix = "terraform import"
 var terraformResourceNamePrefix = "terraform_managed_resource"
@@ -118,6 +118,8 @@ func init() {
 	if err = viper.BindEnv("terraform-install-path", "CLOUDFLARE_TERRAFORM_INSTALL_PATH"); err != nil {
 		log.Fatal(err)
 	}
+
+	rootCmd.PersistentFlags().BoolVarP(&useModernImportBlock, "modern-import-block", "", false, "Whether to generate HCL import blocks for generated resources instead of `terraform import` compatible CLI commands. This is only compatible with Terraform 1.5+")
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
In Terraform 1.5+, there is now the [option to import resources using a HCL block alongside your resources code][1]. This commit updates the `import` command to support that conditional generation if the `—modern-import-block` flag is used.

CLI compatible output

```
terraform import cloudflare_ruleset.terraform_managed_resource_c311c194ead8414c985c44eb4710d435 zone/0d555506aec9767e661a2e19e6d4e711/c311c194ead8414c985c44eb4710d435
terraform import cloudflare_ruleset.terraform_managed_resource_64a2203f3c0246bebc2f39b886d54982 zone/0d555506aec9767e661a2e19e6d4e711/64a2203f3c0246bebc2f39b886d54982
```

HCL block import output

```hcl
import {
  to = cloudflare_ruleset.terraform_managed_resource_c311c194ead8414c985c44eb4710d435
  id = "zone/0d555506aec9767e661a2e19e6d4e711/c311c194ead8414c985c44eb4710d435"
}

import {
  to = cloudflare_ruleset.terraform_managed_resource_64a2203f3c0246bebc2f39b886d54982
  id = "zone/0d555506aec9767e661a2e19e6d4e711/64a2203f3c0246bebc2f39b886d54982"
}
```

[1]: https://developer.hashicorp.com/terraform/language/import