### PR TITLE
Fix `go install` command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ $ brew install cloudflare/cloudflare/cf-terraforming
 ### Go
 
 ```bash
-$ go install github.com/cloudflare/cf-terraforming/internal/app/cf-terraforming@latest
+$ go install github.com/cloudflare/cf-terraforming/cmd/cf-terraforming@latest
 ```
 
 If you use another OS, you will need to download the release directly from


### PR DESCRIPTION
The previous command recommended by the `README.md` file does not appear to work:
```
go: downloading github.com/cloudflare/cf-terraforming v0.16.1
go: github.com/cloudflare/cf-terraforming/internal/app/cf-terraforming@latest: module github.com/cloudflare/cf-terraforming@latest found (v0.16.1), but does not contain package github.com/cloudflare/cf-terraforming/internal/app/cf-terraforming
```

I have tested the new command with: `go version go1.21.4 linux/amd64`
