### PR TITLE
Use static resource ID if "id" field is nil

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -1176,7 +1176,7 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 			structData := jsonStructData[i].(map[string]interface{})
 
 			resourceID := ""
-			if os.Getenv("USE_STATIC_RESOURCE_IDS") == "true" {
+			if structData["id"] == nil || os.Getenv("USE_STATIC_RESOURCE_IDS") == "true" {
 				resourceID = "terraform_managed_resource"
 			} else {
 				id := ""


### PR DESCRIPTION
This is currently the case for Secondary DNS records. In the future these records will get their own IDs, but for now, let's do this to prevent a panic when casting a nil `interface{}` to a string.

References: DNS-10305