### PR TITLE
WaitingRoomSettings - fix interface {} is nil, not string error

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -1030,18 +1030,22 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 					log.Fatal(err)
 				}
 			case "cloudflare_waiting_room_settings":
-				jsonPayload, err := api.GetWaitingRoomSettings(context.Background(), cloudflare.ZoneIdentifier(zoneID))
+				waitingRoomSettings, err := api.GetWaitingRoomSettings(context.Background(), cloudflare.ZoneIdentifier(zoneID))
 				if err != nil {
 					log.Fatal(err)
 				}
+				var jsonPayload []cloudflare.WaitingRoomSettings
+				jsonPayload = append(jsonPayload, waitingRoomSettings)
+
 				resourceCount = 1
-				var jsonPayloadInterface interface{}
 				m, _ := json.Marshal(jsonPayload)
-				err = json.Unmarshal(m, &jsonPayloadInterface)
+				err = json.Unmarshal(m, &jsonStructData)
 				if err != nil {
 					log.Fatal(err)
 				}
-				jsonStructData = []interface{}{jsonPayloadInterface}
+
+				jsonStructData[0].(map[string]interface{})["id"] = zoneID
+				jsonStructData[0].(map[string]interface{})["search_engine_crawler_bypass"] = waitingRoomSettings.SearchEngineCrawlerBypass
 			case "cloudflare_workers_kv_namespace":
 				jsonPayload, _, err := api.ListWorkersKVNamespaces(context.Background(), identifier, cloudflare.ListWorkersKVNamespacesParams{})
 				if err != nil {


### PR DESCRIPTION
running `$ ./cf-terraforming generate --resource-type "cloudflare_waiting_room_settings"`

results in the following error

```
panic: interface conversion: interface {} is nil, not string

goroutine 1 [running]:
github.com/cloudflare/cf-terraforming/internal/app/cf-terraforming/cmd.init.generateResources.func2(0x1400024ca00?, {0x1009f18b8?, 0x4?, 0x1009f1840?})
        /Users/tjozsa/cf-repos/github/cf-terraforming/internal/app/cf-terraforming/cmd/generate.go:1198 +0x4cb0
github.com/spf13/cobra.(*Command).execute(0x101040200, {0x1400007bfa0, 0x2, 0x2})
        pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:987 +0x814
github.com/spf13/cobra.(*Command).ExecuteC(0x10103ff20)
        pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
        pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/cloudflare/cf-terraforming/internal/app/cf-terraforming/cmd.Execute()
        /Users/tjozsa/cf-repos/github/cf-terraforming/internal/app/cf-terraforming/cmd/root.go:30 +0x24
main.main()
        /Users/tjozsa/cf-repos/github/cf-terraforming/cmd/cf-terraforming/main.go:8 +0x1c
```

This PR aims to fix that.