### PR TITLE
Fix waiting room rules resource ID

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -1079,6 +1079,7 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 					log.Fatal(err)
 				}
 				roomRules := []struct {
+					ID            string                       `json:"id"`
 					WaitingRoomID string                       `json:"waiting_room_id"`
 					Rules         []cloudflare.WaitingRoomRule `json:"rules"`
 				}{}
@@ -1090,9 +1091,11 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 						log.Fatal(err)
 					}
 					roomRules = append(roomRules, struct {
+						ID            string                       `json:"id"`
 						WaitingRoomID string                       `json:"waiting_room_id"`
 						Rules         []cloudflare.WaitingRoomRule `json:"rules"`
 					}{
+						ID:            waitingRooms[i].ID,
 						WaitingRoomID: waitingRooms[i].ID,
 						Rules:         rules,
 					})


### PR DESCRIPTION
The lack of ID was causing nil dereference errors further down.

```
panic: interface conversion: interface {} is nil, not string

goroutine 1 [running]:
github.com/cloudflare/cf-terraforming/internal/app/cf-terraforming/cmd.init.generateResources.func3(0x10591f540, {0x10529f7ab?, 0x4?, 0x10529f72b?})
        src/github.com/cloudflare/cf-terraforming/internal/app/cf-terraforming/cmd/generate.go:1276 +0x565c
github.com/spf13/cobra.(*Command).execute(0x10591f540, {0x14000159b00, 0x4, 0x4})
        pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:987 +0x828
github.com/spf13/cobra.(*Command).ExecuteC(0x10591f260)
        pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
        pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/cloudflare/cf-terraforming/internal/app/cf-terraforming/cmd.Execute()
        src/github.com/cloudflare/cf-terraforming/internal/app/cf-terraforming/cmd/root.go:30 +0x24
main.main()
        src/github.com/cloudflare/cf-terraforming/cmd/cf-terraforming/main.go:8 +0x1c
```

This PR doesn't change the generated Terraform code, just the ID used for the Terraform state.