### PR TITLE
extends error message given no resources found by resource type

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -1255,7 +1255,7 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 			}
 			// If we don't have any resources to generate, just bail out early.
 			if resourceCount == 0 {
-				fmt.Fprint(cmd.OutOrStderr(), "no resources found to generate")
+				fmt.Fprintf(cmd.OutOrStderr(), "no resources of type %q found to generate", resourceType)
 				return
 			}
 


### PR DESCRIPTION
Small addition to an error message. As this is my first time writing Go, I used what was in the repo as a guide. Since this is a rather small change, it should hopefully work.

Resolves #694.