### PR TITLE
generate: remove additional handling of numeric values

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate_test.go
+++ b/internal/app/cf-terraforming/cmd/generate_test.go
@@ -112,7 +112,7 @@ func TestResourceGeneration(t *testing.T) {
 		"cloudflare health check":                           {identiferType: "zone", resourceType: "cloudflare_healthcheck", testdataFilename: "cloudflare_healthcheck"},
 		"cloudflare load balancer monitor":                  {identiferType: "account", resourceType: "cloudflare_load_balancer_monitor", testdataFilename: "cloudflare_load_balancer_monitor"},
 		"cloudflare load balancer pool":                     {identiferType: "account", resourceType: "cloudflare_load_balancer_pool", testdataFilename: "cloudflare_load_balancer_pool"},
-		// "cloudflare load balancer":                           {identiferType: "zone", resourceType: "cloudflare_load_balancer", testdataFilename: "cloudflare_load_balancer"},
+		"cloudflare load balancer":                           {identiferType: "zone", resourceType: "cloudflare_load_balancer", testdataFilename: "cloudflare_load_balancer"},
 		"cloudflare logpush jobs with filter":                {identiferType: "zone", resourceType: "cloudflare_logpush_job", testdataFilename: "cloudflare_logpush_job_with_filter"},
 		"cloudflare logpush jobs":                            {identiferType: "zone", resourceType: "cloudflare_logpush_job", testdataFilename: "cloudflare_logpush_job"},
 		"cloudflare managed headers":                         {identiferType: "zone", resourceType: "cloudflare_managed_headers", testdataFilename: "cloudflare_managed_headers"},

--- a/internal/app/cf-terraforming/cmd/util.go
+++ b/internal/app/cf-terraforming/cmd/util.go
@@ -240,15 +240,11 @@ func writeAttrLine(key string, value interface{}, parentName string, body *hclwr
 
 		ctyMap := make(map[string]cty.Value)
 		for _, v := range sortedKeys {
-			if hasNumber(v) {
-				ctyMap[fmt.Sprintf("%s", v)] = cty.StringVal(values[v].(string))
-			} else {
-				switch val := values[v].(type) {
-				case string:
-					ctyMap[v] = cty.StringVal(val)
-				case float64:
-					ctyMap[v] = cty.NumberFloatVal(val)
-				}
+			switch val := values[v].(type) {
+			case string:
+				ctyMap[v] = cty.StringVal(val)
+			case float64:
+				ctyMap[v] = cty.NumberFloatVal(val)
 			}
 		}
 		body.SetAttributeValue(key, cty.ObjectVal(ctyMap))

--- a/testdata/cloudflare/cloudflare_load_balancer.yaml
+++ b/testdata/cloudflare/cloudflare_load_balancer.yaml
@@ -1,87 +1,74 @@
 ---
 version: 1
 interactions:
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-    url: https://api.cloudflare.com/client/v4/zones/0da42c8d2132a9ddaf714f9e7c920711/load_balancers
-    method: GET
-  response:
-    body: |
-      {
-        "success": true,
-        "errors": [],
-        "messages": [],
-        "result": [
-          {
-            "id": "699d98642c564d2e855e9661899b7252",
-            "created_on": "2014-01-01T05:20:00.12345Z",
-            "modified_on": "2014-01-01T05:20:00.12345Z",
-            "description": "Load Balancer for www.example.com",
-            "name": "www.example.com",
-            "enabled": true,
-            "ttl": 30,
-            "proxied": false,
-            "fallback_pool": "17b5962d775c646f3f9725cbc7a53df4",
-            "default_pools": [
-              "17b5962d775c646f3f9725cbc7a53df4",
-              "9290f38c5d07c2e2f4df57b1f61d4196",
-              "00920f38ce07c2e2f4df50b1f61d4194"
-            ],
-            "region_pools": {
-              "ENAM": [
+  - request:
+      body: ""
+      form: {}
+      headers:
+        Content-Type:
+          - application/json
+      url: https://api.cloudflare.com/client/v4/zones/0da42c8d2132a9ddaf714f9e7c920711/load_balancers
+      method: GET
+    response:
+      body: |
+        {
+          "success": true,
+          "errors": [],
+          "messages": [],
+          "result": [
+            {
+              "id": "699d98642c564d2e855e9661899b7252",
+              "created_on": "2014-01-01T05:20:00.12345Z",
+              "modified_on": "2014-01-01T05:20:00.12345Z",
+              "description": "Load Balancer for www.example.com",
+              "name": "www.example.com",
+              "enabled": true,
+              "ttl": 30,
+              "proxied": false,
+              "fallback_pool": "17b5962d775c646f3f9725cbc7a53df4",
+              "default_pools": [
+                "17b5962d775c646f3f9725cbc7a53df4",
+                "9290f38c5d07c2e2f4df57b1f61d4196",
                 "00920f38ce07c2e2f4df50b1f61d4194"
               ],
-              "WNAM": [
-                "de90f38ced07c2e2f4df50b1f61d4194",
-                "9290f38c5d07c2e2f4df57b1f61d4196"
-              ]
-            },
-            "pop_pools": {
-              "LAX": [
-                "de90f38ced07c2e2f4df50b1f61d4194",
-                "9290f38c5d07c2e2f4df57b1f61d4196"
-              ],
-              "LHR": [
-                "abd90f38ced07c2e2f4df50b1f61d4194",
-                "f9138c5d07c2e2f4df57b1f61d4196"
-              ],
-              "SJC": [
-                "00920f38ce07c2e2f4df50b1f61d4194"
-              ]
-            },
-            "country_pools": {
-              "AU": [
-                "de90f38ced07c2e2f4df50b1f61d4194",
-                "9290f38c5d07c2e2f4df57b1f61d4196"
-              ],
-              "ME": [
-                "00920f38ce07c2e2f4df50b1f61d4194"
-              ],
-              "US": [
-                "abd90f38ced07c2e2f4df50b1f61d4194",
-                "f9138c5d07c2e2f4df57b1f61d4196"
-              ]
-            },
-            "steering_policy": "dynamic_latency",
-            "session_affinity": "cookie",
-            "session_affinity_attributes": {
-              "samesite": "Auto",
-              "secure": "Auto",
-              "drain_duration": 100
-            },
-            "session_affinity_ttl": 5000
-          }
-        ]
-      }
-    headers:
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept-Encoding
-    status: 200 OK
-    code: 200
-    duration: ""
+              "region_pools": {
+                "ENAM": [
+                  "00920f38ce07c2e2f4df50b1f61d4194"
+                ]
+              },
+              "pop_pools": {
+                "SJC": [
+                  "00920f38ce07c2e2f4df50b1f61d4194"
+                ]
+              },
+              "country_pools": {
+                "AU": [
+                  "de90f38ced07c2e2f4df50b1f61d4194",
+                  "9290f38c5d07c2e2f4df57b1f61d4196"
+                ]
+              },
+              "steering_policy": "dynamic_latency",
+              "session_affinity": "cookie",
+              "session_affinity_attributes": {
+                "samesite": "Auto",
+                "secure": "Auto",
+                "drain_duration": 100
+              },
+              "session_affinity_ttl": 5000,
+              "random_steering": {
+                "default_weight": 1,
+                "pool_weights": {
+                  "2c3f886957b4112bfaca8b12d87ce8c1": 0
+                }
+              }
+            }
+          ]
+        }
+      headers:
+        Content-Type:
+          - application/json
+        Vary:
+          - Accept-Encoding
+      status: 200 OK
+      code: 200
+      duration: ""

--- a/testdata/terraform/cloudflare_load_balancer/test.tf
+++ b/testdata/terraform/cloudflare_load_balancer/test.tf
@@ -14,33 +14,19 @@ resource "cloudflare_load_balancer" "terraform_managed_resource" {
     country  = "AU"
     pool_ids = ["de90f38ced07c2e2f4df50b1f61d4194", "9290f38c5d07c2e2f4df57b1f61d4196"]
   }
-  country_pools {
-    country  = "ME"
-    pool_ids = ["00920f38ce07c2e2f4df50b1f61d4194"]
-  }
-  country_pools {
-    country  = "US"
-    pool_ids = ["abd90f38ced07c2e2f4df50b1f61d4194", "f9138c5d07c2e2f4df57b1f61d4196"]
-  }
-  pop_pools {
-    pool_ids = ["de90f38ced07c2e2f4df50b1f61d4194", "9290f38c5d07c2e2f4df57b1f61d4196"]
-    pop      = "LAX"
-  }
-  pop_pools {
-    pool_ids = ["abd90f38ced07c2e2f4df50b1f61d4194", "f9138c5d07c2e2f4df57b1f61d4196"]
-    pop      = "LHR"
-  }
   pop_pools {
     pool_ids = ["00920f38ce07c2e2f4df50b1f61d4194"]
     pop      = "SJC"
   }
+  random_steering {
+    default_weight = 1
+    pool_weights = {
+      "2c3f886957b4112bfaca8b12d87ce8c1" = 0
+    }
+  }
   region_pools {
     pool_ids = ["00920f38ce07c2e2f4df50b1f61d4194"]
     region   = "ENAM"
-  }
-  region_pools {
-    pool_ids = ["de90f38ced07c2e2f4df50b1f61d4194", "9290f38c5d07c2e2f4df57b1f61d4196"]
-    region   = "WNAM"
   }
   session_affinity_attributes {
     drain_duration = 100


### PR DESCRIPTION
In previous versions of our schema converter, we needed to handle the scenario
where a key inside of a map would contain a numeric value.

Note: This is only required for `TypeMap`s because it is the wild west and you
lose most of the validation with the Terraform internals when using maps.

```hcl
resource "..." "..." {
  foo = {
    bar1 = "baz"
  }
}
```

While numeric characters in attribute keys are permitted in HCL, they must be
quoted. Inadvertently, it looks like this was also being applied to the
attribute values. While a good measure, this isn't as important as we have
better measures to detect the value type and infer it appropriately.

This commit removes the additional handling and instead relies on the explicit
`.(type)` check instead which covers the key _and_ value.