### PR TITLE
Adding cloudflare_access_application import support

### DIFF
--- a/internal/app/cf-terraforming/cmd/import.go
+++ b/internal/app/cf-terraforming/cmd/import.go
@@ -17,6 +17,7 @@ import (
 // resourceImportStringFormats contains a mapping of the resource type to the
 // composite ID that is compatible with performing an import.
 var resourceImportStringFormats = map[string]string{
+	"cloudflare_access_application":    ":account_id/:id",
 	"cloudflare_access_group":          ":account_id/:id",
 	"cloudflare_access_rule":           ":identifier_type/:identifier_value/:id",
 	"cloudflare_account_member":        ":account_id/:id",
@@ -79,6 +80,17 @@ func runImport() func(cmd *cobra.Command, args []string) {
 		resources := strings.Split(resourceType, ",")
 		for _, resourceType := range resources {
 			switch resourceType {
+			case "cloudflare_access_application":
+				jsonPayload, _, err := api.ListAccessApplications(context.Background(), identifier, cloudflare.ListAccessApplicationsParams{})
+				if err != nil {
+					log.Fatal(err)
+				}
+
+				m, _ := json.Marshal(jsonPayload)
+				err = json.Unmarshal(m, &jsonStructData)
+				if err != nil {
+					log.Fatal(err)
+				}
 			case "cloudflare_access_group":
 				jsonPayload, _, err := api.ListAccessGroups(context.Background(), identifier, cloudflare.ListAccessGroupsParams{})
 				if err != nil {


### PR DESCRIPTION
Closes https://github.com/cloudflare/cf-terraforming/issues/704

Tested locally and was able to generate the appropriate import commands:

`terraform import cloudflare_access_application.terraform_managed_resource_<app_id> <account_id>/<app_id>
`