### PR TITLE
Add ai_bots_protection to bot management tests

### DIFF
--- a/testdata/cloudflare/cloudflare_bot_management.yaml
+++ b/testdata/cloudflare/cloudflare_bot_management.yaml
@@ -19,6 +19,7 @@ interactions:
         "messages": [],
         "result": {
           "enable_js": true,
+          "ai_bots_protection": "block",
           "sbfm_definitely_automated": "block",
           "sbfm_likely_automated": "managed_challenge",
           "sbfm_verified_bots": "allow",

--- a/testdata/terraform/cloudflare_bot_management/test.tf
+++ b/testdata/terraform/cloudflare_bot_management/test.tf
@@ -1,10 +1,10 @@
 resource "cloudflare_bot_management" "terraform_managed_resource" {
+  ai_bots_protection              = "block"
   enable_js                       = true
   optimize_wordpress              = true
   sbfm_definitely_automated       = "block"
   sbfm_likely_automated           = "managed_challenge"
   sbfm_static_resource_protection = false
   sbfm_verified_bots              = "allow"
-  ai_bots_protection              = "block"
   zone_id                         = "0da42c8d2132a9ddaf714f9e7c920711"
 }

--- a/testdata/terraform/cloudflare_bot_management/test.tf
+++ b/testdata/terraform/cloudflare_bot_management/test.tf
@@ -5,5 +5,6 @@ resource "cloudflare_bot_management" "terraform_managed_resource" {
   sbfm_likely_automated           = "managed_challenge"
   sbfm_static_resource_protection = false
   sbfm_verified_bots              = "allow"
+  ai_bots_protection              = "block"
   zone_id                         = "0da42c8d2132a9ddaf714f9e7c920711"
 }


### PR DESCRIPTION
Adds tests for `ai_bots_protection` field in `cloudflare_bot_management` resource.

**NOTE**: For this to work cloudflare-go needs to be bumped to 0.104.0 