### PR TITLE
Improve API error handling for `generate`

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -134,6 +135,13 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 
 				err := client.Get(context.Background(), endpoint, nil, &result)
 				if err != nil {
+					var apierr *cloudflare.Error
+					if errors.As(err, &apierr) {
+						if apierr.StatusCode == http.StatusNotFound {
+							log.Debugf("no resources found at %s. skipping...", endpoint)
+							continue
+						}
+					}
 					log.Fatalf("failed to fetch API endpoint: %s", err)
 				}
 

--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -151,6 +151,10 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 				}
 
 				value := gjson.Get(string(body), "result")
+				if value.Type == gjson.Null {
+					log.Debugf("no result found at %s. skipping...", endpoint)
+					continue
+				}
 				err = json.Unmarshal([]byte(value.String()), &jsonStructData)
 				if err != nil {
 					log.Fatalf("failed to unmarshal result: %s", err)


### PR DESCRIPTION
Handle some edge cases in the v5 operations due to the internal SDK and endpoint response.