### PR TITLE
fix: handle failure to fetch versions gracefully

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -83,6 +83,10 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 		}
 
 		_, providerVersion, err := tf.Version(context.Background(), true)
+		if err != nil {
+			log.Fatalf("failed to retrieve terraform and provider version information: %s", err)
+		}
+
 		providerVersionString := providerVersion[providerRegistryHostname+"/cloudflare/cloudflare"].String()
 		log.WithFields(logrus.Fields{
 			"version": providerVersionString,

--- a/internal/app/cf-terraforming/cmd/import.go
+++ b/internal/app/cf-terraforming/cmd/import.go
@@ -121,6 +121,10 @@ func runImport() func(cmd *cobra.Command, args []string) {
 		}
 
 		_, providerVersion, err := tf.Version(context.Background(), true)
+		if err != nil {
+			log.Fatalf("failed to retrieve terraform and provider version information: %s", err)
+		}
+
 		providerVersionString = providerVersion[providerRegistryHostname+"/cloudflare/cloudflare"].String()
 		log.WithFields(logrus.Fields{
 			"version": providerVersionString,


### PR DESCRIPTION
If for any reason, we cannot get Terraform or provider versions, we can exit cleanly instead of crashing.