### PR TITLE
chore: handle non-standard registries more automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Flags:
       --hostname string                     Hostname to use to query the API
   -k, --key string                          API Key generated on the 'My Profile' page. See: https://dash.cloudflare.com/profile
       --modern-import-block                 Whether to generate HCL import blocks for generated resources instead of terraform import compatible CLI commands. This is only compatible with Terraform 1.5+
-      --provider-registry-hostname string   Hostname to use for provider registry lookups (default "registry.terraform.io")
       --resource-type string                Comma delimitered string of which resource(s) you wish to generate
       --terraform-binary-path string        Path to an existing Terraform binary (otherwise, one will be downloaded)
       --terraform-install-path string       Path to an initialized Terraform working directory (default ".")
@@ -182,14 +181,6 @@ cf-terraforming import \
   --zone $CLOUDFLARE_ZONE_ID
 ```
 
-## Using non-standard registries
-
-By default, we use the Hashicorp registry (registry.terraform.io) for looking up
-the provider to introspect the schema. If you are attempting to use another
-registry, you will need to provide the `--provider-registry-hostname` flag or
-`CLOUDFLARE_PROVIDER_REGISTRY_HOSTNAME` environment variable to query the correct
-registry.
-
 ## Using non-standard Terraform binaries
 
 Internally, we use [`terraform-exec`](https://github.com/hashicorp/terraform-exec)
@@ -206,7 +197,7 @@ existing binary, or you wish to provide a Terraform compatible binary (such as
 ## CDKTF
 
 If you'd like to use [cdktf](https://developer.hashicorp.com/terraform/cdktf)
-for your project resources, you can pipe the output from `cf-terraforming` into 
+for your project resources, you can pipe the output from `cf-terraforming` into
 `cdktf convert` in order to correctly generate CDKTF output automatically.
 
 Example:

--- a/internal/app/cf-terraforming/cmd/import.go
+++ b/internal/app/cf-terraforming/cmd/import.go
@@ -115,7 +115,9 @@ func runImport() func(cmd *cobra.Command, args []string) {
 
 		// Setup and configure Terraform to operate in the temporary directory where
 		// the provider is already configured.
-		log.Debugf("initializing Terraform in %s", workingDir)
+		log.WithFields(logrus.Fields{
+			"directory": workingDir,
+		}).Debug("initializing Terraform")
 		tf, err := tfexec.NewTerraform(workingDir, execPath)
 		if err != nil {
 			log.Fatal(err)
@@ -126,9 +128,25 @@ func runImport() func(cmd *cobra.Command, args []string) {
 			log.Fatalf("failed to retrieve terraform and provider version information: %s", err)
 		}
 
-		providerVersionString = providerVersion[providerRegistryHostname+"/cloudflare/cloudflare"].String()
+		var registryPath string
+		for provider := range providerVersion {
+			if strings.Contains(provider, "/cloudflare/cloudflare") {
+				registryPath = provider
+				continue
+			}
+		}
+
+		detectedVersion, ok := providerVersion[registryPath]
+		if !ok {
+			log.WithFields(logrus.Fields{
+				"available_registries": providerVersion,
+			}).Fatal("failed to find registry")
+		}
+
+		providerVersionString := detectedVersion.String()
 		log.WithFields(logrus.Fields{
-			"version": providerVersionString,
+			"version":  providerVersionString,
+			"registry": registryPath,
 		}).Debug("detected provider")
 
 		var jsonStructData []interface{}

--- a/internal/app/cf-terraforming/cmd/root.go
+++ b/internal/app/cf-terraforming/cmd/root.go
@@ -1,13 +1,14 @@
 package cmd
 
 import (
+	"strings"
+
 	cfv0 "github.com/cloudflare/cloudflare-go"
 	"github.com/cloudflare/cloudflare-go/v4"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"strings"
 )
 
 var (
@@ -124,7 +125,7 @@ func init() {
 		log.Fatal(err)
 	}
 
-	rootCmd.PersistentFlags().StringVarP(&providerRegistryHostname, "provider-registry-hostname", "", "registry.terraform.io", "Hostname to use for provider registry lookups")
+	rootCmd.PersistentFlags().StringVarP(&providerRegistryHostname, "provider-registry-hostname", "", "", "Hostname to use for provider registry lookups. Deprecated: this is no longer needed to be configured for custom registries.")
 	if err = viper.BindPFlag("provider-registry-hostname", rootCmd.PersistentFlags().Lookup("provider-registry-hostname")); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
When everyone was upset with Hashicorp and creating their own registries, it was the wild west and we didn't really have a great way to universally detect the registry in use without it being explicitly provided.

Fast forward to today, everyone* now ships this as part of their state implementation (like Hashicorp always did) so it's easier to determine the registry once it is initialised.

_* Well, anyone that has a > 0.01% footprint for usage._