### PR TITLE
fix: do not emit "data" and "content" for DNS records

### DIFF
--- a/internal/app/cf-terraforming/cmd/generate.go
+++ b/internal/app/cf-terraforming/cmd/generate.go
@@ -906,6 +906,11 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 						jsonStructData[i].(map[string]interface{})["proxiable"] = nil
 						jsonStructData[i].(map[string]interface{})["value"] = nil
 
+						_, hasData := jsonStructData[i].(map[string]interface{})["data"]
+						if hasData {
+							jsonStructData[i].(map[string]interface{})["content"] = nil
+						}
+
 						if jsonStructData[i].(map[string]interface{})["name"].(string) != zone.Name {
 							jsonStructData[i].(map[string]interface{})["name"] = strings.ReplaceAll(jsonStructData[i].(map[string]interface{})["name"].(string), "."+zone.Name, "")
 						}
@@ -1590,6 +1595,13 @@ func generateResources() func(cmd *cobra.Command, args []string) {
 func processCustomCasesV5(response *[]interface{}, resourceType string, pathParam string) {
 	resourceCount := len(*response)
 	switch resourceType {
+	case "cloudflare_dns_record":
+		for i := 0; i < resourceCount; i++ {
+			_, hasData := (*response)[i].(map[string]interface{})["data"]
+			if hasData {
+				delete((*response)[i].(map[string]interface{}), "content")
+			}
+		}
 	case "cloudflare_managed_transforms":
 		// remap email and role_ids into the right structure and remove policies
 		for i := 0; i < resourceCount; i++ {


### PR DESCRIPTION
I've tried `cf-terraforming` for Cloudflare DNS. However for records like SRV, CAA, LOC etc.  the tool generates `content` and `data`. It looks something like this:

```
resource "cloudflare_dns_record" "terraform_managed_resource_xyz" {
  content = "0 issuewild \"amazonaws.com\""
  name    = "mydomain.tld"
  proxied = false
  ttl     = 1
  type    = "CAA"
  zone_id = "abc"
  data = {
    flags = 0
    tag   = "issuewild"
    value = "amazonaws.com"
  }
  settings = {}
}
```

This is valid terraform but `content` and `data` are mutually exclusive attributes.

If you try terraform plan or apply on this you will get:
```
│ Error: Invalid Attribute Combination
│ Attribute "content" cannot be specified when "data" is specified
```
hence you can never really use the automatically generated data without additional post-processing.

Patch simply prefers `data`. Might be there is an easier way to achieve this, this simple "hack" worked for me tho, feel free to treat this just as a feature request and do it in a different way. Thanks.