### PR TITLE
deps: bump cloudflare-go to v0.117.0 for asset_name support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- deps: bump `cloudflare-go` to v0.117.0 to pick up `asset_name` support for `cloudflare_ruleset` `http_custom_errors` `serve_error` rules ([APIX-861](https://jira.cfdata.org/browse/APIX-861))
+
 ## 0.6.0 (2021-12-14)
 
 - generate: add support for nested map interfaces in request ([#332](https://github.com/cloudflare/cf-terraforming/pull/332))

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
-	github.com/cloudflare/cloudflare-go v0.115.0
+	github.com/cloudflare/cloudflare-go v0.117.0
 	github.com/cloudflare/cloudflare-go/v4 v4.4.0
 	github.com/dnaeon/go-vcr v1.2.0
 	github.com/hashicorp/go-version v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-github.com/cloudflare/cloudflare-go v0.115.0 h1:84/dxeeXweCc0PN5Cto44iTA8AkG1fyT11yPO5ZB7sM=
-github.com/cloudflare/cloudflare-go v0.115.0/go.mod h1:Ds6urDwn/TF2uIU24mu7H91xkKP8gSAHxQ44DSZgVmU=
+github.com/cloudflare/cloudflare-go v0.117.0 h1:y00E0XCvxuZGplL+gkoMRIhWpfNqIgyBFS6UUWC4s0c=
+github.com/cloudflare/cloudflare-go v0.117.0/go.mod h1:Ds6urDwn/TF2uIU24mu7H91xkKP8gSAHxQ44DSZgVmU=
 github.com/cloudflare/cloudflare-go/v4 v4.4.0 h1:orwng6AQRTPi9p0Vsd1K6hb6qxai9PTS2eStnV+LTAk=
 github.com/cloudflare/cloudflare-go/v4 v4.4.0/go.mod h1:XcYpLe7Mf6FN87kXzEWVnJ6z+vskW/k6eUqgqfhFE9k=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=


### PR DESCRIPTION
Picks up [cloudflare/cloudflare-go#4312](https://github.com/cloudflare/cloudflare-go/pull/4312) (released as `v0.117.0`), which adds `AssetName` to `RulesetRuleActionParameters`. This fixes the silent drop of `asset_name` in generated HCL for `http_custom_errors` `serve_error` rules.

## Why

Prior to this bump, `cf-terraforming generate --resource-type=cloudflare_ruleset` would omit `action_parameters.asset_name` for every `serve_error` rule, because the underlying `cloudflare-go@v0.115.0` struct didn't model the field. Generated configs diverged from the live ruleset and produced drift on the first `terraform plan`.

## Verification

Ran the original reproduction against a zone with a configured custom error `asset_name` and confirmed it now surfaces in generated HCL when using `terraform-provider-cloudflare` v5:

```hcl
resource "cloudflare_ruleset" "terraform_managed_resource_..." {
  phase = "http_custom_errors"
  rules = [{
    action = "serve_error"
    action_parameters = {
      asset_name   = "test"
      content_type = "text/html"
    }
    ...
  }]
}
```

Provider v4.46.0 still drops the attribute because its schema doesn't model `asset_name` (a gap in `terraform-provider-cloudflare` v4, out of scope here).

## Changelog

`deps: bump cloudflare-go to v0.117.0 to pick up asset_name support for cloudflare_ruleset http_custom_errors serve_error rules`

## Tracking

- Internal: APIX-861 (root-cause Bug), APIOPS-12531 (Kamino dependency bump)
- Upstream SDK fix: cloudflare/cloudflare-go#4312