### PR TITLE
fix(test): update impersonation_registry fixture for new schema fields

### DIFF
--- a/testdata/terraform/v5/cloudflare_email_security_impersonation_registry/test.tf
+++ b/testdata/terraform/v5/cloudflare_email_security_impersonation_registry/test.tf
@@ -1,7 +1,10 @@
 resource "cloudflare_email_security_impersonation_registry" "terraform_managed_resource" {
-  account_id     = "f037e56e89293a057740de681ac9abbe"
-  email          = "email"
-  is_email_regex = true
-  name           = "name"
+  account_id                 = "f037e56e89293a057740de681ac9abbe"
+  directory_id               = 0
+  email                      = "email"
+  external_directory_node_id = "12444788"
+  is_email_regex             = true
+  name                       = "name"
+  provenance                 = "A1S_INTERNAL"
 }
 


### PR DESCRIPTION
The provider v5.22.0 added `directory_id`, `external_directory_node_id`, and `provenance` to the `cloudflare_email_security_impersonation_registry` schema as Optional attributes. The VCR cassette already contained these fields in the API response, but the expected HCL fixture was not updated, causing `TestResourceGenerationV5/cloudflare_email_security_impersonation_registry` to fail on master.

Updates the fixture to match the actual generate output.