### PR TITLE
fix(ci): bump homebrew formula action to v4

### DIFF
--- a/.github/workflows/bump-formula.yaml
+++ b/.github/workflows/bump-formula.yaml
@@ -20,7 +20,7 @@ jobs:
           else
             echo "tag-name=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           fi
-      - uses: mislav/bump-homebrew-formula-action@v3
+      - uses: mislav/bump-homebrew-formula-action@v4
         with:
           formula-name: cf-terraforming
           formula-path: cf-terraforming.rb


### PR DESCRIPTION
Bumps `mislav/bump-homebrew-formula-action` from v3 to v4 for Node.js 24 compatibility.

The v3 action targets Node.js 20 which is deprecated on GitHub Actions runners and being forced to Node.js 24. This may be contributing to the `HTTP 303` errors on the Homebrew formula bump workflow (ref: #980).