### PR TITLE
feat: preserve content_converter in v4 rulesets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- deps: bump `cloudflare-go` to v0.118.0 to preserve `content_converter` for `cloudflare_ruleset` `http_config_settings` `set_config` rules
 - deps: bump `cloudflare-go` to v0.117.0 to pick up `asset_name` support for `cloudflare_ruleset` `http_custom_errors` `serve_error` rules ([APIX-861](https://jira.cfdata.org/browse/APIX-861))
 
 ## 0.6.0 (2021-12-14)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
-	github.com/cloudflare/cloudflare-go v0.117.0
+	github.com/cloudflare/cloudflare-go v0.118.0
 	github.com/cloudflare/cloudflare-go/v4 v4.4.0
 	github.com/dnaeon/go-vcr v1.2.0
 	github.com/hashicorp/go-version v1.9.0

--- a/internal/app/cf-terraforming/cmd/generate_test.go
+++ b/internal/app/cf-terraforming/cmd/generate_test.go
@@ -135,6 +135,7 @@ func TestResourceGenerationV4(t *testing.T) {
 		"cloudflare record subdomain":                        {identiferType: "zone", resourceType: "cloudflare_record", testdataFilename: "cloudflare_record_subdomain"},
 		"cloudflare record TXT SPF":                          {identiferType: "zone", resourceType: "cloudflare_record", testdataFilename: "cloudflare_record_txt_spf"},
 		"cloudflare ruleset (ddos_l7)":                       {identiferType: "zone", resourceType: "cloudflare_ruleset", testdataFilename: "cloudflare_ruleset_zone_ddos_l7"},
+		"cloudflare ruleset (content_converter)":             {identiferType: "zone", resourceType: "cloudflare_ruleset", testdataFilename: "cloudflare_ruleset_http_config_settings_content_converter"},
 		"cloudflare ruleset (http_log_custom_fields)":        {identiferType: "zone", resourceType: "cloudflare_ruleset", testdataFilename: "cloudflare_ruleset_zone_http_log_custom_fields"},
 		"cloudflare ruleset (http_ratelimit)":                {identiferType: "zone", resourceType: "cloudflare_ruleset", testdataFilename: "cloudflare_ruleset_zone_http_ratelimit"},
 		"cloudflare ruleset (http_request_cache_settings)":   {identiferType: "zone", resourceType: "cloudflare_ruleset", testdataFilename: "cloudflare_ruleset_http_request_cache_settings"},

--- a/testdata/cloudflare/v4/cloudflare_ruleset_http_config_settings_content_converter.yaml
+++ b/testdata/cloudflare/v4/cloudflare_ruleset_http_config_settings_content_converter.yaml
@@ -1,0 +1,81 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: https://api.cloudflare.com/client/v4/zones/0da42c8d2132a9ddaf714f9e7c920711/rulesets
+    method: GET
+  response:
+    body: |
+      {
+        "result": [
+          {
+            "id": "a6905ff86d3844cebc1a88dd80c659e7",
+            "name": "default",
+            "description": "",
+            "source": "zone",
+            "kind": "zone",
+            "version": "1",
+            "last_updated": "2026-08-29T00:00:00Z",
+            "phase": "http_config_settings"
+          }
+        ],
+        "success": true,
+        "errors": [],
+        "messages": []
+      }
+    headers:
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: https://api.cloudflare.com/client/v4/zones/0da42c8d2132a9ddaf714f9e7c920711/rulesets/a6905ff86d3844cebc1a88dd80c659e7
+    method: GET
+  response:
+    body: |
+      {
+        "result": {
+          "id": "a6905ff86d3844cebc1a88dd80c659e7",
+          "name": "default",
+          "description": "",
+          "kind": "zone",
+          "version": "1",
+          "phase": "http_config_settings",
+          "rules": [
+            {
+              "id": "0f24aab3002347a9a4ac01520e6893d0",
+              "version": "1",
+              "action": "set_config",
+              "expression": "true",
+              "description": "convert HTML to Markdown",
+              "last_updated": "2026-08-29T00:00:00Z",
+              "ref": "0f24aab3002347a9a4ac01520e6893d0",
+              "enabled": true,
+              "action_parameters": {
+                "content_converter": false
+              }
+            }
+          ],
+          "last_updated": "2026-08-29T00:00:00Z"
+        },
+        "success": true,
+        "errors": [],
+        "messages": []
+      }
+    headers:
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/testdata/terraform/v4/cloudflare_ruleset_http_config_settings_content_converter/provider.tf
+++ b/testdata/terraform/v4/cloudflare_ruleset_http_config_settings_content_converter/provider.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4"
+    }
+  }
+}

--- a/testdata/terraform/v4/cloudflare_ruleset_http_config_settings_content_converter/test.tf
+++ b/testdata/terraform/v4/cloudflare_ruleset_http_config_settings_content_converter/test.tf
@@ -1,0 +1,15 @@
+resource "cloudflare_ruleset" "terraform_managed_resource" {
+  kind    = "zone"
+  name    = "default"
+  phase   = "http_config_settings"
+  zone_id = "0da42c8d2132a9ddaf714f9e7c920711"
+  rules {
+    action = "set_config"
+    action_parameters {
+      content_converter = false
+    }
+    description = "convert HTML to Markdown"
+    enabled     = true
+    expression  = "true"
+  }
+}


### PR DESCRIPTION
## Summary
- bump legacy `cloudflare-go` to the expected v0.118.0 release
- add a v4 `http_config_settings` Rulesets cassette
- verify generated HCL preserves `content_converter = false`

## Dependencies
- cloudflare/cloudflare-go#4359 must release as v0.118.0 first
- v4 provider release with `content_converter` schema support required for fixture validation

## Tests
- fixture formatting and YAML validation pass
- generation test not run without Cloudflare credentials